### PR TITLE
fix: jvp in cfd Tesseract should only return derivative

### DIFF
--- a/demo/cfd/cfd-tesseract/tesseract_api.py
+++ b/demo/cfd/cfd-tesseract/tesseract_api.py
@@ -204,7 +204,7 @@ def jvp_jit(
         filtered_apply,
         [flatten_with_paths(inputs, include_paths=jvp_inputs)],
         [tangent_vector],
-    )
+    )[1]
 
 
 @eqx.filter_jit


### PR DESCRIPTION
#### Relevant issue or PR
Fixes small deviation from jax recipe introduced in pasteurlabs/tesseract-jax#10

#### Description of changes
Even though it is not used in the cfd demo, `jvp_jit` should follow the jax recipe and only return the derivative.

#### Testing done
Manual: Tesseract still builds and notebook still runs after changes

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract-jax/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Heiko Zimmermann heiko.zimmermann@simulation.science
