### PR TITLE
fix: Divergence free /= incompressibility

### DIFF
--- a/examples/cfd/demo.ipynb
+++ b/examples/cfd/demo.ipynb
@@ -416,7 +416,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We define the loss function, which additionally ensures physical realism of the initial condition by penalizing the flow's divergence (incompressibility)."
+    "We define the loss function, which additionally ensures physical realism of the initial condition by penalizing the flow's divergence."
    ]
   },
   {


### PR DESCRIPTION
Divergence free is not the same incompressibility.

<!--
Please use a PR title that conforms to *conventional commits*: "<commit_type>: Describe your change"; for example: "fix: prevent race condition". Some other commit types are: fix, feat, ci, doc, refactor...
For a full list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

#### Relevant issue or PR
<!-- If the changes resolve an issue or follow some other PR, link to them here. Only link something if it is directly relevant. -->

#### Description of changes
<!-- Add a high-level description of changes, focusing on the *what* and *why*. -->

non divergent => incompressible but incompressible => non divergent does not hold

#### Testing done
<!-- Describe how the changes were tested; e.g., "CI passes", "Tested manually in stagingrepo#123", screenshots of a terminal session that verify the changes, or any other evidence of testing the changes. -->

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract-jax/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Andrin Rehmann andrin.rehmann@simulation.science
