### PR TITLE
fix: use has_side_effect=True in FFI calls

### DIFF
--- a/tesseract_jax/primitive.py
+++ b/tesseract_jax/primitive.py
@@ -229,7 +229,7 @@ def tesseract_dispatch_lowering(
         array_args,
         ctx.avals_in,
         ctx.avals_out,
-        has_side_effect=False,
+        has_side_effect=True,
     )
     ctx.module_context.add_keepalive(keepalive)
     return result


### PR DESCRIPTION
The [JAX docs](https://docs.jax.dev/en/latest/_autosummary/jax.pure_callback.html) state this:

> In the context of JAX transformations, Python exceptions should be considered side-effects: this means that intentionally raising an error within a pure_callback breaks the API contract, and the behavior of the resulting program is undefined.

Our callbacks can raise, so switching `has_side_effect` to `True` seems like the safer option. I don't know if this has any runtime impact right now (didn't notice any while testing).