### PR TITLE
fix: update version in vectoradd_jax example to not result in invalid docker tag

### DIFF
--- a/examples/simple/vectoradd_jax/tesseract_config.yaml
+++ b/examples/simple/vectoradd_jax/tesseract_config.yaml
@@ -1,5 +1,5 @@
 name: vectoradd_jax
-version: "2025/02/05"
+version: "2025-02-05"
 description: |
   Tesseract that adds/subtracts two vectors. Uses jax internally.
 


### PR DESCRIPTION
#### Description of changes
Updated version in `vectoradd_jax` example to not result in invalid docker tag
