### PR TITLE
fix: Adapt version of vectoradd_jax to new Tesseract conventions

### DIFF
--- a/examples/simple/vectoradd_jax/tesseract_config.yaml
+++ b/examples/simple/vectoradd_jax/tesseract_config.yaml
@@ -1,5 +1,5 @@
 name: vectoradd_jax
-version: "2025-02-05"
+version: "1.0.0"
 description: |
   Tesseract that adds/subtracts two vectors. Uses jax internally.
 


### PR DESCRIPTION
#### Relevant issue or PR
A job on main fails https://github.com/pasteurlabs/tesseract-jax/actions/runs/17833574910/job/50704738666#step:8:132

#### Description of changes
removed the version previously being used, which is incompatible with tesseract >=1.0.0 conventions