### PR TITLE
ci: Always run examples, fix fem example

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -6,8 +6,6 @@ on:
       - main
 
   pull_request:
-    paths:
-      - examples/**
 
 jobs:
   tests:

--- a/examples/fem-shapeopt/fem_tess/tesseract_environment.yaml
+++ b/examples/fem-shapeopt/fem_tess/tesseract_environment.yaml
@@ -7,7 +7,7 @@ dependencies:
   - scipy==1.15.2
   - matplotlib==3.10.3
   - meshio==5.3.5
-  - petsc4py==3.23.3
+  - petsc4py==3.24.2
   - fenics==2019.1.0
   - gmsh==4.13.1
   - python-gmsh==4.13.1


### PR DESCRIPTION
<!--
Please use a PR title that conforms to *conventional commits*: "<commit_type>: Describe your change"; for example: "fix: prevent race condition". Some other commit types are: fix, feat, ci, doc, refactor...
For a full list of commit types visit https://www.conventionalcommits.org/en/v1.0.0/
-->

#### Relevant issue or PR
<!-- If the changes resolve an issue or follow some other PR, link to them here. Only link something if it is directly relevant. -->
https://github.com/pasteurlabs/tesseract-jax/actions/runs/20179185599/job/57935023708
#117 

#### Description of changes
<!-- Add a high-level description of changes, focusing on the *what* and *why*. -->
Our jax-fem example started failing silently. Underlying error appears to be due to incorrect linking of MPI libraries. These libraries are required for petsc, one of packages jax-fem uses under the hood. I am not quite sure what triggered this error, certainly not tess-jax changes. However updating petsc4py to the latest version seems to fix it.

Additionally, I've enabled examples to run on every PR, which is much more observable than silent error on main. These examples take few minutes to run, but hopefully now that the project is not in an active dev phase this is acceptable.

#### Testing done
<!-- Describe how the changes were tested; e.g., "CI passes", "Tested manually in stagingrepo#123", screenshots of a terminal session that verify the changes, or any other evidence of testing the changes. -->
* `uv run --no-sync jupyter nbconvert --to notebook --execute demo.ipynb` runs on an isolated GCP instance.
* CI (now with examples!) passes
