### PR TITLE
fix: prevent random deadlocks by not allocating JAX memory from within callbacks

### DIFF
--- a/docs/content/get-started.md
+++ b/docs/content/get-started.md
@@ -75,3 +75,25 @@ When creating a new Tesseract based on a JAX function, use `tesseract init --rec
 ```
 
 - **Non-differentiable inputs/outputs**: Differentiating through inputs or outputs not marked as `Differentiable[...]` in the Tesseract schema can raise a `ValueError` or produce `NaN` tangents. See the [Handling Differentiability](handling-differentiability.md) page for details and workarounds.
+
+- **No JAX operations inside `from_tesseract_api` endpoints**: When using `Tesseract.from_tesseract_api(...)`, the `apply`, `vector_jacobian_product`, and `jacobian_vector_product` functions in your `tesseract_api.py` execute inside JAX FFI callbacks. **Using `jax.numpy` or any other JAX operation that allocates arrays in these functions can cause deadlocks**, because JAX's runtime is already holding a lock during the callback.
+
+  Use plain NumPy instead:
+
+  ```python
+  # ❌ Bad — will deadlock under jit/grad
+  import jax.numpy as jnp
+
+  def apply(inputs):
+      return OutputSchema(c=jnp.sin(inputs.a))
+
+  # ✅ Good — use numpy for in-process Tesseracts
+  import numpy as np
+
+  def apply(inputs):
+      return OutputSchema(c=np.sin(inputs.a))
+  ```
+
+  ```{note}
+  This only affects `from_tesseract_api` (in-process execution). Tesseracts served via Docker (`from_image`) run in a separate process and are not subject to this restriction.
+  ```

--- a/tesseract_jax/tesseract_compat.py
+++ b/tesseract_jax/tesseract_compat.py
@@ -158,7 +158,7 @@ class Jaxeract:
             if path in out_data:
                 out.append(out_data[path])
             else:
-                out.append(np.full_like(aval, np.nan))
+                out.append(np.full(aval.shape, np.nan, dtype=aval.dtype))
 
         return tuple(out)
 

--- a/tesseract_jax/tesseract_compat.py
+++ b/tesseract_jax/tesseract_compat.py
@@ -4,6 +4,7 @@
 from typing import Any
 
 import jax.tree
+import numpy as np
 from jax import ShapeDtypeStruct
 from jax.tree_util import PyTreeDef
 from jax.typing import ArrayLike
@@ -15,6 +16,9 @@ from tesseract_jax.tree_util import (
     combine_args,
     unflatten_args,
 )
+
+# WARNING: Do NOT use jax.numpy within Jaxeract methods, as they are executed from within FFI callbacks
+# and cannot safely allocate JAX arrays. Use vanilla numpy instead.
 
 
 class Jaxeract:
@@ -154,7 +158,7 @@ class Jaxeract:
             if path in out_data:
                 out.append(out_data[path])
             else:
-                out.append(jax.numpy.full_like(aval, jax.numpy.nan))
+                out.append(np.full_like(aval, np.nan))
 
         return tuple(out)
 
@@ -221,9 +225,9 @@ class Jaxeract:
                 # Non-differentiable but non-static input: return zero gradient
                 # with the same shape/dtype as the corresponding input array
                 out.append(
-                    jax.numpy.full(
+                    np.full(
                         array_args[array_idx].shape,
-                        jax.numpy.nan,
+                        np.nan,
                         dtype=array_args[array_idx].dtype,
                     )
                 )


### PR DESCRIPTION
#### Relevant issue or PR

n/a

#### Description of changes

Through some very painful debugging I realized that using `jax.numpy` from within Python callbacks can lead to deadlocks (which makes intuitive sense to me, since it's kind of doing JAX-in-JAX which seems icky at best). Let's only return NumPy arrays instead.

#### Testing done

manual, deadlock resolved
