### PR TITLE
feat: use DCE to leverage Tesseract's partial differentiation

### DIFF
--- a/tesseract_jax/dce.py
+++ b/tesseract_jax/dce.py
@@ -1,0 +1,136 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dead-code-elimination rule for the ``tesseract_dispatch`` primitive.
+
+Forward-mode AD requests the derivative of *every* differentiable output even
+when only a few survive downstream (e.g. ``jacfwd`` of a function that returns
+one leaf of a multi-output Tesseract). JAX exposes the survivors to a primitive's
+DCE rule, letting us narrow the requested sub-block (``live_output_paths`` /
+``live_input_paths``) and drop the dead outvars so the Tesseract computes only
+what is used.
+
+Like :mod:`tesseract_jax.batching`, this module holds primitive-agnostic logic —
+it operates purely on the ``JaxprEqn`` and never imports ``tesseract_dispatch_p``;
+the rule is registered against the primitive in :mod:`tesseract_jax.primitive`.
+"""
+
+import jax.tree
+from jax._src.interpreters import partial_eval as pe
+
+try:
+    # Preferred location (jax >= ~0.4.34, required on 0.10 to avoid a deprecation
+    # warning). Falls back to ``jax.core`` on our 0.7.0 lower bound, where
+    # ``jax.extend.core.DropVar`` does not yet exist.
+    from jax.extend.core import DropVar, JaxprEqn
+except ImportError:  # pragma: no cover - exercised only on older JAX
+    from jax.core import DropVar
+    from jax.extend.core import JaxprEqn
+
+from tesseract_jax.tree_util import (
+    _pytree_to_tesseract_flat,
+    live_jvp_output_positions,
+)
+
+
+def tesseract_dispatch_dce_rule(
+    used_outputs: list[bool], eqn: JaxprEqn
+) -> tuple[list[bool], JaxprEqn | None]:
+    """Drop dead derivative outputs from a ``tesseract_dispatch`` equation.
+
+    JAX surfaces which outputs survive downstream as ``used_outputs``; we narrow
+    the requested sub-block (via ``live_output_paths`` / ``live_input_paths``) and
+    drop the dead outvars so the Tesseract computes only what is used.
+
+    Only ``jacobian`` and ``jacobian_vector_product`` carry prunable output
+    structure; ``apply`` and ``vector_jacobian_product`` defer to JAX's default
+    rule. This optimisation only kicks in when JAX runs DCE — i.e. under ``jit``
+    (any mode) and un-jitted reverse mode; un-jitted ``jacfwd`` is unaffected.
+
+    Inputs are always kept: the endpoints evaluate the full primal regardless of
+    which input columns are differentiated, so pruning ``used_inputs`` would be
+    incorrect.
+    """
+    # Effects-aware whole-equation drop (matches the un-pruned default exactly).
+    if not any(used_outputs):
+        return pe._default_dce_rule(used_outputs, eqn)
+
+    eval_func = eqn.params["eval_func"]
+    if eval_func == "jacobian":
+        return _dce_jacobian(used_outputs, eqn)
+    if eval_func == "jacobian_vector_product":
+        return _dce_jacobian_vector_product(used_outputs, eqn)
+    return pe._default_dce_rule(used_outputs, eqn)
+
+
+def _dce_jacobian(
+    used_outputs: list[bool], eqn: JaxprEqn
+) -> tuple[list[bool], JaxprEqn | None]:
+    """Prune a ``jacobian`` equation's (out x in) block grid to its live rectangle."""
+    in_paths = eqn.params.get("live_input_paths")
+    out_paths = eqn.params.get("live_output_paths")
+    if in_paths is None or out_paths is None:
+        # No explicit path layout to map ``used_outputs`` onto; keep everything.
+        return [True] * len(eqn.invars), eqn
+
+    n_in, n_out = len(in_paths), len(out_paths)
+    # Row-major layout: outvar ``i * n_in + j`` is block (out_path i, in_path j).
+    used = [[used_outputs[i * n_in + j] for j in range(n_in)] for i in range(n_out)]
+    live_out = [i for i in range(n_out) if any(used[i])]
+    live_in = [j for j in range(n_in) if any(used[i][j] for i in range(n_out))]
+
+    new_params = dict(
+        eqn.params,
+        live_output_paths=tuple(out_paths[i] for i in live_out),
+        live_input_paths=tuple(in_paths[j] for j in live_in),
+    )
+    # Emit the live rectangle in the same row-major order abstract_eval expects.
+    # Blocks inside the rectangle that are individually dead become DropVars.
+    new_outvars = [
+        eqn.outvars[i * n_in + j]
+        if used_outputs[i * n_in + j]
+        else DropVar(eqn.outvars[i * n_in + j].aval)
+        for i in live_out
+        for j in live_in
+    ]
+    return [True] * len(eqn.invars), eqn.replace(outvars=new_outvars, params=new_params)
+
+
+def _dce_jacobian_vector_product(
+    used_outputs: list[bool], eqn: JaxprEqn
+) -> tuple[list[bool], JaxprEqn | None]:
+    """Prune a ``jacobian_vector_product`` equation's dead output tangents."""
+    params = eqn.params
+    client = params["client"]
+    output_pytreedef = params["output_pytreedef"]
+    n_outputs = len(params["output_avals"])
+    diff_output_paths = client.differentiable_output_paths
+
+    # Positions this bind currently emits (in output_avals order). Must line up
+    # 1:1 with ``used_outputs`` / ``eqn.outvars``.
+    cur_positions = live_jvp_output_positions(
+        output_pytreedef, n_outputs, diff_output_paths, params.get("live_output_paths")
+    )
+    flat_items = list(
+        _pytree_to_tesseract_flat(
+            jax.tree.unflatten(output_pytreedef, range(n_outputs)),
+            schema_paths=diff_output_paths,
+        ).items()
+    )
+
+    new_outvars = []
+    live_paths = []
+    for k, pos in enumerate(cur_positions):
+        path, is_diff = flat_items[pos]
+        if is_diff is None:
+            # Non-differentiable leaf: always retained (it has no path to name and
+            # its tangent is a cheap NaN), but DropVar it when dead.
+            ov = eqn.outvars[k]
+            new_outvars.append(ov if used_outputs[k] else DropVar(ov.aval))
+        elif used_outputs[k]:
+            new_outvars.append(eqn.outvars[k])
+            live_paths.append(path)
+        # else: differentiable but dead -> dropped from the output contract.
+
+    new_params = dict(params, live_output_paths=tuple(live_paths))
+    return [True] * len(eqn.invars), eqn.replace(outvars=new_outvars, params=new_params)

--- a/tesseract_jax/primitive.py
+++ b/tesseract_jax/primitive.py
@@ -67,8 +67,8 @@ def tesseract_dispatch_abstract_eval(
     eval_func: str,
     vmap_method: VmapMethod = None,
     materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
+    live_input_paths: tuple[str, ...] | None = None,
+    live_output_paths: tuple[str, ...] | None = None,
     jac_mode: Literal["fwd", "bwd"] = "bwd",
 ) -> tuple:
     """Define how to dispatch evals and pipe arguments."""
@@ -89,7 +89,7 @@ def tesseract_dispatch_abstract_eval(
 
     if eval_func == "jacobian":
         # One array per (diff_output, diff_input) pair, shape = out_shape + in_shape.
-        # `jac_input_paths` / `jac_output_paths` (when provided) restrict the
+        # `live_input_paths` / `live_output_paths` (when provided) restrict the
         # request to a sub-block of the Jacobian.
         primal_avals = array_args[:n_primals]
         primal_inputs = unflatten_args(
@@ -113,13 +113,13 @@ def tesseract_dispatch_abstract_eval(
             if v is not None
         }
         jac_inputs = (
-            list(jac_input_paths)
-            if jac_input_paths is not None
+            list(live_input_paths)
+            if live_input_paths is not None
             else list(path_to_shape.keys())
         )
         jac_outputs = (
-            list(jac_output_paths)
-            if jac_output_paths is not None
+            list(live_output_paths)
+            if live_output_paths is not None
             else list(out_path_to_aval.keys())
         )
         # Per JAX convention: fwd-mode → output dtype (jacfwd), bwd-mode →
@@ -220,7 +220,7 @@ def tesseract_dispatch_jvp_rule(
     # size such a mask and it keeps the inherited value -- as does `res`, which
     # reproduces the original call over the original operands.
     #
-    # Not cosmetic: the batching rule turns `has_tangent` into `jac_input_paths`,
+    # Not cosmetic: the batching rule turns `has_tangent` into `live_input_paths`,
     # i.e. which columns of the Jacobian get requested, so an inherited mask
     # over-fetches whenever only some arguments are differentiated.
     # `jacfwd(lin_fn, argnums=0)` would ask for every column and then multiply the
@@ -394,8 +394,8 @@ def tesseract_dispatch(
     eval_func: str,
     vmap_method: VmapMethod = None,
     materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
+    live_input_paths: tuple[str, ...] | None = None,
+    live_output_paths: tuple[str, ...] | None = None,
     jac_mode: Literal["fwd", "bwd"] = "bwd",
 ) -> Any:
     """Defines how to dispatch lowering the computation.
@@ -406,8 +406,8 @@ def tesseract_dispatch(
 
     extra_kwargs: dict[str, Any] = {}
     if eval_func == "jacobian":
-        extra_kwargs["jac_input_paths"] = jac_input_paths
-        extra_kwargs["jac_output_paths"] = jac_output_paths
+        extra_kwargs["live_input_paths"] = live_input_paths
+        extra_kwargs["live_output_paths"] = live_output_paths
         extra_kwargs["jac_mode"] = jac_mode
 
     def _dispatch(*args: ArrayLike) -> Any:
@@ -446,8 +446,8 @@ def tesseract_dispatch_lowering(
     eval_func: str,
     vmap_method: VmapMethod = None,
     materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
+    live_input_paths: tuple[str, ...] | None = None,
+    live_output_paths: tuple[str, ...] | None = None,
     jac_mode: Literal["fwd", "bwd"] = "bwd",
 ) -> Any:
     """Defines how to dispatch lowering the computation."""
@@ -455,8 +455,8 @@ def tesseract_dispatch_lowering(
 
     extra_kwargs: dict[str, Any] = {}
     if eval_func == "jacobian":
-        extra_kwargs["jac_input_paths"] = jac_input_paths
-        extra_kwargs["jac_output_paths"] = jac_output_paths
+        extra_kwargs["live_input_paths"] = live_input_paths
+        extra_kwargs["live_output_paths"] = live_output_paths
         extra_kwargs["jac_mode"] = jac_mode
 
     def _dispatch(*args: ArrayLike) -> Any:
@@ -515,8 +515,8 @@ def tesseract_dispatch_batching(
     eval_func: str,
     vmap_method: VmapMethod = None,
     materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
+    live_input_paths: tuple[str, ...] | None = None,
+    live_output_paths: tuple[str, ...] | None = None,
     jac_mode: Literal["fwd", "bwd"] = "bwd",
 ) -> Any:
     """Defines how to dispatch batch operations such as vmap (which is used by jax.jacobian)."""
@@ -666,8 +666,8 @@ def _batched_via_jacobian(
         client=client,
         eval_func="jacobian",
         vmap_method=None,
-        jac_input_paths=tuple(diff_input_path_to_pos),
-        jac_output_paths=tuple(diff_output_path_to_pos),
+        live_input_paths=tuple(diff_input_path_to_pos),
+        live_output_paths=tuple(diff_output_path_to_pos),
         jac_mode="fwd" if eval_func == "jacobian_vector_product" else "bwd",
     )
     n_in = len(diff_input_path_to_pos)

--- a/tesseract_jax/primitive.py
+++ b/tesseract_jax/primitive.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 import jax.tree
 import numpy as np
 from jax import ShapeDtypeStruct, dtypes, extend
+from jax._src.interpreters import partial_eval as pe
 from jax.core import ShapedArray
 from jax.interpreters import ad, batching, mlir
 from jax.tree_util import PyTreeDef
@@ -21,9 +22,18 @@ from tesseract_jax.batching import VMAP_METHOD_DISPATCH, VmapMethod
 from tesseract_jax.tesseract_compat import Jaxeract
 from tesseract_jax.tree_util import (
     _pytree_to_tesseract_flat,
+    live_jvp_output_positions,
     split_args,
     unflatten_args,
 )
+
+try:
+    # Preferred location (jax >= ~0.4.34, required on 0.10 to avoid a deprecation
+    # warning). Falls back to ``jax.core`` on our 0.7.0 lower bound, where
+    # ``jax.extend.core.DropVar`` does not yet exist.
+    from jax.extend.core import DropVar
+except ImportError:  # pragma: no cover - exercised only on older JAX
+    from jax.core import DropVar
 
 tesseract_dispatch_p = extend.core.Primitive("tesseract_dispatch")
 tesseract_dispatch_p.multiple_results = True
@@ -135,9 +145,22 @@ def tesseract_dispatch_abstract_eval(
                 )
         return tuple(avals_out)
 
-    # Those have the same shape as the outputs
+    # apply / jvp emit one aval per (live) output leaf with the output's shape.
+    # `live_output_paths` (set by the DCE rule) prunes the jvp output tangents to
+    # those still used downstream; non-differentiable leaves are always retained
+    # and apply is never pruned.
     assert eval_func in ("apply", "jacobian_vector_product")
-    return tuple(jax.core.ShapedArray(aval.shape, aval.dtype) for aval in output_avals)
+    if eval_func == "jacobian_vector_product":
+        positions = live_jvp_output_positions(
+            output_pytreedef,
+            len(output_avals),
+            client.differentiable_output_paths,
+            live_output_paths,
+        )
+        selected = tuple(output_avals[p] for p in positions)
+    else:
+        selected = output_avals
+    return tuple(jax.core.ShapedArray(aval.shape, aval.dtype) for aval in selected)
 
 
 def tesseract_dispatch_jvp_rule(
@@ -284,6 +307,9 @@ def tesseract_dispatch_transpose_rule(
     eval_func: str,
     vmap_method: VmapMethod = None,
     materialize_jacobian: bool | None = None,
+    live_input_paths: tuple[str, ...] | None = None,
+    live_output_paths: tuple[str, ...] | None = None,
+    jac_mode: Literal["fwd", "bwd"] = "bwd",
 ) -> tuple[ArrayLike | None, ...]:
     """Defines how to dispatch vjp operation."""
     assert eval_func in ("jacobian_vector_product",)
@@ -306,6 +332,26 @@ def tesseract_dispatch_transpose_rule(
             "  primals = (x,)\n"
             "  jax.linear_transpose(lambda t: jax.jvp(f, primals, (t,))[1], x)"
         )
+
+    # The forward-mode DCE rule may have pruned this jvp equation's outputs down
+    # to ``live_output_paths``, in which case ``cotangent`` only carries the live
+    # leaves. Scatter them back to the full output layout (symbolic zeros for the
+    # pruned leaves) so the logic below — and the VJP it dispatches — sees the
+    # un-pruned structure. ``live_output_paths is None`` ⇒ nothing was pruned.
+    if live_output_paths is not None:
+        live_positions = live_jvp_output_positions(
+            output_pytreedef,
+            len(output_avals),
+            client.differentiable_output_paths,
+            live_output_paths,
+        )
+        full_cotangent: list[Any] = [
+            ad.Zero(jax.core.ShapedArray(aval.shape, aval.dtype))
+            for aval in output_avals
+        ]
+        for k, pos in enumerate(live_positions):
+            full_cotangent[pos] = cotangent[k]
+        cotangent = full_cotangent
 
     # Raise if a cotangent for a non-differentiable output is not a symbolic zero.
     # Symbolic zeros (ad.Zero) are produced by JAX when gradients are blocked
@@ -373,6 +419,29 @@ def tesseract_dispatch_transpose_rule(
 ad.primitive_transposes[tesseract_dispatch_p] = tesseract_dispatch_transpose_rule
 
 
+def _endpoint_extra_kwargs(
+    eval_func: str,
+    live_input_paths: tuple[str, ...] | None,
+    live_output_paths: tuple[str, ...] | None,
+    jac_mode: Literal["fwd", "bwd"],
+) -> dict[str, Any]:
+    """Endpoint kwargs that restrict the requested sub-block of the derivative.
+
+    ``live_*_paths`` (set by the DCE rule) tell the ``jacobian`` /
+    ``jacobian_vector_product`` endpoints to compute only the still-live rows /
+    columns. ``None`` means "compute everything" (the un-pruned default).
+    """
+    if eval_func == "jacobian":
+        return {
+            "live_input_paths": live_input_paths,
+            "live_output_paths": live_output_paths,
+            "jac_mode": jac_mode,
+        }
+    if eval_func == "jacobian_vector_product":
+        return {"live_output_paths": live_output_paths}
+    return {}
+
+
 def _raise_if_unimplemented(eval_func: str, client: Jaxeract) -> None:
     if eval_func not in client.available_methods:
         raise NotImplementedError(
@@ -404,11 +473,9 @@ def tesseract_dispatch(
     """
     _raise_if_unimplemented(eval_func, client)
 
-    extra_kwargs: dict[str, Any] = {}
-    if eval_func == "jacobian":
-        extra_kwargs["live_input_paths"] = live_input_paths
-        extra_kwargs["live_output_paths"] = live_output_paths
-        extra_kwargs["jac_mode"] = jac_mode
+    extra_kwargs = _endpoint_extra_kwargs(
+        eval_func, live_input_paths, live_output_paths, jac_mode
+    )
 
     def _dispatch(*args: ArrayLike) -> Any:
         static_args_ = tuple(_unpack_hashable(arg) for arg in static_args)
@@ -453,11 +520,9 @@ def tesseract_dispatch_lowering(
     """Defines how to dispatch lowering the computation."""
     _raise_if_unimplemented(eval_func, client)
 
-    extra_kwargs: dict[str, Any] = {}
-    if eval_func == "jacobian":
-        extra_kwargs["live_input_paths"] = live_input_paths
-        extra_kwargs["live_output_paths"] = live_output_paths
-        extra_kwargs["jac_mode"] = jac_mode
+    extra_kwargs = _endpoint_extra_kwargs(
+        eval_func, live_input_paths, live_output_paths, jac_mode
+    )
 
     def _dispatch(*args: ArrayLike) -> Any:
         static_args_ = tuple(_unpack_hashable(arg) for arg in static_args)
@@ -768,6 +833,115 @@ def _rmatmul(matrix: Any, batched_vector: Any) -> Any:
 
 
 batching.primitive_batchers[tesseract_dispatch_p] = tesseract_dispatch_batching
+
+
+def tesseract_dispatch_dce_rule(
+    used_outputs: list[bool], eqn: extend.core.JaxprEqn
+) -> tuple[list[bool], extend.core.JaxprEqn | None]:
+    """Drop dead derivative outputs from a ``tesseract_dispatch`` equation.
+
+    Forward-mode AD requests the derivative of *every* differentiable output even
+    when only a few survive downstream (e.g. ``jacfwd`` of a function that returns
+    one leaf of a multi-output Tesseract). JAX surfaces the survivors here as
+    ``used_outputs``; we narrow the requested sub-block (via ``live_output_paths``
+    / ``live_input_paths``) and drop the dead outvars so the Tesseract computes
+    only what is used.
+
+    Only ``jacobian`` and ``jacobian_vector_product`` carry prunable output
+    structure; ``apply`` and ``vector_jacobian_product`` defer to JAX's default
+    rule. This optimisation only kicks in when JAX runs DCE — i.e. under ``jit``
+    (any mode) and un-jitted reverse mode; un-jitted ``jacfwd`` is unaffected.
+
+    Inputs are always kept: the endpoints evaluate the full primal regardless of
+    which input columns are differentiated, so pruning ``used_inputs`` would be
+    incorrect.
+    """
+    # Effects-aware whole-equation drop (matches the un-pruned default exactly).
+    if not any(used_outputs):
+        return pe._default_dce_rule(used_outputs, eqn)
+
+    eval_func = eqn.params["eval_func"]
+    if eval_func == "jacobian":
+        return _dce_jacobian(used_outputs, eqn)
+    if eval_func == "jacobian_vector_product":
+        return _dce_jacobian_vector_product(used_outputs, eqn)
+    return pe._default_dce_rule(used_outputs, eqn)
+
+
+def _dce_jacobian(
+    used_outputs: list[bool], eqn: extend.core.JaxprEqn
+) -> tuple[list[bool], extend.core.JaxprEqn | None]:
+    """Prune a ``jacobian`` equation's (out x in) block grid to its live rectangle."""
+    in_paths = eqn.params.get("live_input_paths")
+    out_paths = eqn.params.get("live_output_paths")
+    if in_paths is None or out_paths is None:
+        # No explicit path layout to map ``used_outputs`` onto; keep everything.
+        return [True] * len(eqn.invars), eqn
+
+    n_in, n_out = len(in_paths), len(out_paths)
+    # Row-major layout: outvar ``i * n_in + j`` is block (out_path i, in_path j).
+    used = [[used_outputs[i * n_in + j] for j in range(n_in)] for i in range(n_out)]
+    live_out = [i for i in range(n_out) if any(used[i])]
+    live_in = [j for j in range(n_in) if any(used[i][j] for i in range(n_out))]
+
+    new_params = dict(
+        eqn.params,
+        live_output_paths=tuple(out_paths[i] for i in live_out),
+        live_input_paths=tuple(in_paths[j] for j in live_in),
+    )
+    # Emit the live rectangle in the same row-major order abstract_eval expects.
+    # Blocks inside the rectangle that are individually dead become DropVars.
+    new_outvars = [
+        eqn.outvars[i * n_in + j]
+        if used_outputs[i * n_in + j]
+        else DropVar(eqn.outvars[i * n_in + j].aval)
+        for i in live_out
+        for j in live_in
+    ]
+    return [True] * len(eqn.invars), eqn.replace(outvars=new_outvars, params=new_params)
+
+
+def _dce_jacobian_vector_product(
+    used_outputs: list[bool], eqn: extend.core.JaxprEqn
+) -> tuple[list[bool], extend.core.JaxprEqn | None]:
+    """Prune a ``jacobian_vector_product`` equation's dead output tangents."""
+    params = eqn.params
+    client = params["client"]
+    output_pytreedef = params["output_pytreedef"]
+    n_outputs = len(params["output_avals"])
+    diff_output_paths = client.differentiable_output_paths
+
+    # Positions this bind currently emits (in output_avals order). Must line up
+    # 1:1 with ``used_outputs`` / ``eqn.outvars``.
+    cur_positions = live_jvp_output_positions(
+        output_pytreedef, n_outputs, diff_output_paths, params.get("live_output_paths")
+    )
+    flat_items = list(
+        _pytree_to_tesseract_flat(
+            jax.tree.unflatten(output_pytreedef, range(n_outputs)),
+            schema_paths=diff_output_paths,
+        ).items()
+    )
+
+    new_outvars = []
+    live_paths = []
+    for k, pos in enumerate(cur_positions):
+        path, is_diff = flat_items[pos]
+        if is_diff is None:
+            # Non-differentiable leaf: always retained (it has no path to name and
+            # its tangent is a cheap NaN), but DropVar it when dead.
+            ov = eqn.outvars[k]
+            new_outvars.append(ov if used_outputs[k] else DropVar(ov.aval))
+        elif used_outputs[k]:
+            new_outvars.append(eqn.outvars[k])
+            live_paths.append(path)
+        # else: differentiable but dead -> dropped from the output contract.
+
+    new_params = dict(params, live_output_paths=tuple(live_paths))
+    return [True] * len(eqn.invars), eqn.replace(outvars=new_outvars, params=new_params)
+
+
+pe.dce_rules[tesseract_dispatch_p] = tesseract_dispatch_dce_rule
 
 
 def _check_dtype(dtype: Any) -> None:

--- a/tesseract_jax/primitive.py
+++ b/tesseract_jax/primitive.py
@@ -19,6 +19,7 @@ from jax.typing import ArrayLike
 from tesseract_core import Tesseract
 
 from tesseract_jax.batching import VMAP_METHOD_DISPATCH, VmapMethod
+from tesseract_jax.dce import tesseract_dispatch_dce_rule
 from tesseract_jax.tesseract_compat import Jaxeract
 from tesseract_jax.tree_util import (
     _pytree_to_tesseract_flat,
@@ -26,14 +27,6 @@ from tesseract_jax.tree_util import (
     split_args,
     unflatten_args,
 )
-
-try:
-    # Preferred location (jax >= ~0.4.34, required on 0.10 to avoid a deprecation
-    # warning). Falls back to ``jax.core`` on our 0.7.0 lower bound, where
-    # ``jax.extend.core.DropVar`` does not yet exist.
-    from jax.extend.core import DropVar
-except ImportError:  # pragma: no cover - exercised only on older JAX
-    from jax.core import DropVar
 
 tesseract_dispatch_p = extend.core.Primitive("tesseract_dispatch")
 tesseract_dispatch_p.multiple_results = True
@@ -833,114 +826,6 @@ def _rmatmul(matrix: Any, batched_vector: Any) -> Any:
 
 
 batching.primitive_batchers[tesseract_dispatch_p] = tesseract_dispatch_batching
-
-
-def tesseract_dispatch_dce_rule(
-    used_outputs: list[bool], eqn: extend.core.JaxprEqn
-) -> tuple[list[bool], extend.core.JaxprEqn | None]:
-    """Drop dead derivative outputs from a ``tesseract_dispatch`` equation.
-
-    Forward-mode AD requests the derivative of *every* differentiable output even
-    when only a few survive downstream (e.g. ``jacfwd`` of a function that returns
-    one leaf of a multi-output Tesseract). JAX surfaces the survivors here as
-    ``used_outputs``; we narrow the requested sub-block (via ``live_output_paths``
-    / ``live_input_paths``) and drop the dead outvars so the Tesseract computes
-    only what is used.
-
-    Only ``jacobian`` and ``jacobian_vector_product`` carry prunable output
-    structure; ``apply`` and ``vector_jacobian_product`` defer to JAX's default
-    rule. This optimisation only kicks in when JAX runs DCE — i.e. under ``jit``
-    (any mode) and un-jitted reverse mode; un-jitted ``jacfwd`` is unaffected.
-
-    Inputs are always kept: the endpoints evaluate the full primal regardless of
-    which input columns are differentiated, so pruning ``used_inputs`` would be
-    incorrect.
-    """
-    # Effects-aware whole-equation drop (matches the un-pruned default exactly).
-    if not any(used_outputs):
-        return pe._default_dce_rule(used_outputs, eqn)
-
-    eval_func = eqn.params["eval_func"]
-    if eval_func == "jacobian":
-        return _dce_jacobian(used_outputs, eqn)
-    if eval_func == "jacobian_vector_product":
-        return _dce_jacobian_vector_product(used_outputs, eqn)
-    return pe._default_dce_rule(used_outputs, eqn)
-
-
-def _dce_jacobian(
-    used_outputs: list[bool], eqn: extend.core.JaxprEqn
-) -> tuple[list[bool], extend.core.JaxprEqn | None]:
-    """Prune a ``jacobian`` equation's (out x in) block grid to its live rectangle."""
-    in_paths = eqn.params.get("live_input_paths")
-    out_paths = eqn.params.get("live_output_paths")
-    if in_paths is None or out_paths is None:
-        # No explicit path layout to map ``used_outputs`` onto; keep everything.
-        return [True] * len(eqn.invars), eqn
-
-    n_in, n_out = len(in_paths), len(out_paths)
-    # Row-major layout: outvar ``i * n_in + j`` is block (out_path i, in_path j).
-    used = [[used_outputs[i * n_in + j] for j in range(n_in)] for i in range(n_out)]
-    live_out = [i for i in range(n_out) if any(used[i])]
-    live_in = [j for j in range(n_in) if any(used[i][j] for i in range(n_out))]
-
-    new_params = dict(
-        eqn.params,
-        live_output_paths=tuple(out_paths[i] for i in live_out),
-        live_input_paths=tuple(in_paths[j] for j in live_in),
-    )
-    # Emit the live rectangle in the same row-major order abstract_eval expects.
-    # Blocks inside the rectangle that are individually dead become DropVars.
-    new_outvars = [
-        eqn.outvars[i * n_in + j]
-        if used_outputs[i * n_in + j]
-        else DropVar(eqn.outvars[i * n_in + j].aval)
-        for i in live_out
-        for j in live_in
-    ]
-    return [True] * len(eqn.invars), eqn.replace(outvars=new_outvars, params=new_params)
-
-
-def _dce_jacobian_vector_product(
-    used_outputs: list[bool], eqn: extend.core.JaxprEqn
-) -> tuple[list[bool], extend.core.JaxprEqn | None]:
-    """Prune a ``jacobian_vector_product`` equation's dead output tangents."""
-    params = eqn.params
-    client = params["client"]
-    output_pytreedef = params["output_pytreedef"]
-    n_outputs = len(params["output_avals"])
-    diff_output_paths = client.differentiable_output_paths
-
-    # Positions this bind currently emits (in output_avals order). Must line up
-    # 1:1 with ``used_outputs`` / ``eqn.outvars``.
-    cur_positions = live_jvp_output_positions(
-        output_pytreedef, n_outputs, diff_output_paths, params.get("live_output_paths")
-    )
-    flat_items = list(
-        _pytree_to_tesseract_flat(
-            jax.tree.unflatten(output_pytreedef, range(n_outputs)),
-            schema_paths=diff_output_paths,
-        ).items()
-    )
-
-    new_outvars = []
-    live_paths = []
-    for k, pos in enumerate(cur_positions):
-        path, is_diff = flat_items[pos]
-        if is_diff is None:
-            # Non-differentiable leaf: always retained (it has no path to name and
-            # its tangent is a cheap NaN), but DropVar it when dead.
-            ov = eqn.outvars[k]
-            new_outvars.append(ov if used_outputs[k] else DropVar(ov.aval))
-        elif used_outputs[k]:
-            new_outvars.append(eqn.outvars[k])
-            live_paths.append(path)
-        # else: differentiable but dead -> dropped from the output contract.
-
-    new_params = dict(params, live_output_paths=tuple(live_paths))
-    return [True] * len(eqn.invars), eqn.replace(outvars=new_outvars, params=new_params)
-
-
 pe.dce_rules[tesseract_dispatch_p] = tesseract_dispatch_dce_rule
 
 

--- a/tesseract_jax/primitive.py
+++ b/tesseract_jax/primitive.py
@@ -612,14 +612,6 @@ def tesseract_dispatch_batching(
             and (materialize_jacobian is True or endpoint_available)
         )
         if use_shortcut:
-            # FIXME: `live_input_paths` / `live_output_paths` are dropped here.
-            # `_batched_via_jacobian` recomputes both from the schema and
-            # `has_tangent`, and returns one output per `output_avals` entry, so a
-            # pruned equation reports its full output count down this path while
-            # `tesseract_dispatch_abstract_eval` reports the pruned one. Reachable
-            # since the JVP rule started differentiating derivative endpoints:
-            # `jacfwd(lin_fn, argnums=...)` sends one bind down each path and the
-            # counts disagree.
             return _batched_via_jacobian(
                 array_args,
                 axes,
@@ -631,6 +623,7 @@ def tesseract_dispatch_batching(
                 has_tangent=has_tangent,
                 client=client,
                 eval_func=eval_func,
+                live_output_paths=live_output_paths,
             )
 
     new_args = [
@@ -668,6 +661,7 @@ def _batched_via_jacobian(
     has_tangent: tuple[bool, ...],
     client: Jaxeract,
     eval_func: str,
+    live_output_paths: tuple[str, ...] | None,
 ) -> tuple[tuple, tuple]:
     """Batched JVP / VJP via one ``jacobian`` endpoint call + ``tensordot``.
 
@@ -722,9 +716,15 @@ def _batched_via_jacobian(
 
     # Map each diff output path to its leaf index in the output pytree.
     # ``keys()`` give the path order of the Jacobian's rows; ``values()`` give
-    # the corresponding ``tans`` / ``output_avals`` positions.
+    # the corresponding ``tans`` / ``output_avals`` positions. Rows DCE has already
+    # declared dead are left out of the request entirely. ``live_output_paths`` is
+    # only ever set on a ``jacobian_vector_product`` equation -- the DCE rule defers
+    # ``vector_jacobian_product`` to JAX's default -- so the VJP branch below always
+    # sees the full set and stays in step with the cotangents it is handed.
     diff_output_path_to_pos: dict[str, int] = {
-        p: i for i, (p, v) in enumerate(output_flat.items()) if v is not None
+        p: i
+        for i, (p, v) in enumerate(output_flat.items())
+        if v is not None and (live_output_paths is None or p in live_output_paths)
     }
 
     jac_arrays = tesseract_dispatch_p.bind(
@@ -799,10 +799,21 @@ def _batched_via_jacobian(
             diff_avals,
             jac_blocks,
         )
+        # Emit exactly the leaves this bind is contracted to emit: the
+        # non-differentiable ones (whose tangent is a NaN) plus the differentiable
+        # ones DCE left live. `live_jvp_output_positions` is the shared source of
+        # truth with abstract_eval, so the two agree on the count and the order.
+        positions = live_jvp_output_positions(
+            output_pytreedef,
+            len(output_avals),
+            client.differentiable_output_paths,
+            live_output_paths,
+        )
+        is_diff = [v is not None for _p, v in output_flat.items()]
         outs = _pad_nans(
             diff_outs,
-            output_avals,
-            [v is not None for _p, v in output_flat.items()],
+            [output_avals[pos] for pos in positions],
+            [is_diff[pos] for pos in positions],
         )
         return outs, (0,) * len(outs)
 

--- a/tesseract_jax/primitive.py
+++ b/tesseract_jax/primitive.py
@@ -169,6 +169,8 @@ def tesseract_dispatch_jvp_rule(
     eval_func: str,
     vmap_method: VmapMethod = None,
     materialize_jacobian: bool | None = None,
+    live_input_paths: tuple[str, ...] | None = None,
+    live_output_paths: tuple[str, ...] | None = None,
 ) -> tuple[tuple[ArrayLike, ...], tuple[ArrayLike, ...]]:
     """Defines how to dispatch jvp operation.
 
@@ -265,6 +267,8 @@ def tesseract_dispatch_jvp_rule(
         ),
         vmap_method=vmap_method,
         materialize_jacobian=materialize_jacobian,
+        live_input_paths=live_input_paths,
+        live_output_paths=live_output_paths,
     )
 
     res = tesseract_dispatch_p.bind(
@@ -279,6 +283,8 @@ def tesseract_dispatch_jvp_rule(
         eval_func=eval_func,
         vmap_method=vmap_method,
         materialize_jacobian=materialize_jacobian,
+        live_input_paths=live_input_paths,
+        live_output_paths=live_output_paths,
     )
 
     return tuple(res), tuple(jvp)
@@ -606,6 +612,14 @@ def tesseract_dispatch_batching(
             and (materialize_jacobian is True or endpoint_available)
         )
         if use_shortcut:
+            # FIXME: `live_input_paths` / `live_output_paths` are dropped here.
+            # `_batched_via_jacobian` recomputes both from the schema and
+            # `has_tangent`, and returns one output per `output_avals` entry, so a
+            # pruned equation reports its full output count down this path while
+            # `tesseract_dispatch_abstract_eval` reports the pruned one. Reachable
+            # since the JVP rule started differentiating derivative endpoints:
+            # `jacfwd(lin_fn, argnums=...)` sends one bind down each path and the
+            # counts disagree.
             return _batched_via_jacobian(
                 array_args,
                 axes,

--- a/tesseract_jax/tesseract_compat.py
+++ b/tesseract_jax/tesseract_compat.py
@@ -14,6 +14,7 @@ from tesseract_jax.tree_util import (
     PyTree,
     _pytree_to_tesseract_flat,
     combine_args,
+    live_jvp_output_positions,
     unflatten_args,
 )
 
@@ -126,8 +127,16 @@ class Jaxeract:
         output_avals: tuple[ShapeDtypeStruct, ...],
         is_static_mask: tuple[bool, ...],
         has_tangent: tuple[bool, ...],
+        live_output_paths: tuple[str, ...] | None = None,
     ) -> PyTree:
-        """Call the Tesseract's jvp endpoint with the given arguments."""
+        """Call the Tesseract's jvp endpoint with the given arguments.
+
+        ``live_output_paths`` (set by the DCE rule) restricts the request to the
+        output tangents that survive dead-code elimination. ``None`` requests all
+        differentiable outputs (the un-pruned default). The returned tuple is
+        aligned to the live output leaves in ``output_avals`` order — see
+        :func:`tesseract_jax.tree_util.live_jvp_output_positions`.
+        """
         n_primals = len(is_static_mask) - sum(is_static_mask)
         primals = array_args[:n_primals]
         # array_args[n_primals:] contains ALL tangents (zeroed for has_tangent=False).
@@ -162,7 +171,24 @@ class Jaxeract:
             schema_paths=self.differentiable_output_paths,
         )
 
-        jvp_outputs = [p for p, v in output_flat.items() if v is not None]
+        # Emit only the output tangents that survived DCE (``live_output_paths``).
+        # ``live_output_positions`` is the single source of truth for which leaves
+        # we return and in what order; abstract_eval sizes its result the same way.
+        live_positions = live_jvp_output_positions(
+            output_pytreedef,
+            len(output_avals),
+            self.differentiable_output_paths,
+            live_output_paths,
+        )
+        flat_items = list(output_flat.items())
+
+        # Only differentiable live leaves are requested from the Tesseract;
+        # non-differentiable leaves (if any) are NaN-padded below.
+        jvp_outputs = [
+            flat_items[pos][0]
+            for pos in live_positions
+            if flat_items[pos][1] is not None
+        ]
 
         out_data = self.client.jacobian_vector_product(
             inputs=primal_inputs,
@@ -172,10 +198,12 @@ class Jaxeract:
         )
 
         out = []
-        for path, aval in zip(output_flat, output_avals, strict=False):
+        for pos in live_positions:
+            path = flat_items[pos][0]
             if path in out_data:
                 out.append(out_data[path])
             else:
+                aval = output_avals[pos]
                 out.append(np.full(aval.shape, np.nan, dtype=aval.dtype))
 
         return tuple(out)

--- a/tesseract_jax/tesseract_compat.py
+++ b/tesseract_jax/tesseract_compat.py
@@ -189,8 +189,8 @@ class Jaxeract:
         output_avals: tuple[ShapeDtypeStruct, ...],
         is_static_mask: tuple[bool, ...],
         has_tangent: tuple[bool, ...],
-        jac_input_paths: tuple[str, ...] | None = None,
-        jac_output_paths: tuple[str, ...] | None = None,
+        live_input_paths: tuple[str, ...] | None = None,
+        live_output_paths: tuple[str, ...] | None = None,
         jac_mode: Literal["fwd", "bwd"] = "bwd",
     ) -> PyTree:
         """Call the Tesseract's jacobian endpoint with the given arguments.
@@ -211,19 +211,19 @@ class Jaxeract:
         flat_inputs = _pytree_to_tesseract_flat(
             primal_inputs, schema_paths=self.differentiable_input_paths
         )
-        if jac_input_paths is None:
+        if live_input_paths is None:
             jac_inputs = [p for p, v in flat_inputs.items() if v is not None]
         else:
-            jac_inputs = list(jac_input_paths)
+            jac_inputs = list(live_input_paths)
 
         output_flat = _pytree_to_tesseract_flat(
             jax.tree.unflatten(output_pytreedef, range(len(output_avals))),
             schema_paths=self.differentiable_output_paths,
         )
-        if jac_output_paths is None:
+        if live_output_paths is None:
             jac_outputs = [p for p, v in output_flat.items() if v is not None]
         else:
-            jac_outputs = list(jac_output_paths)
+            jac_outputs = list(live_output_paths)
 
         out_data = self.client.jacobian(
             inputs=primal_inputs,

--- a/tesseract_jax/tree_util.py
+++ b/tesseract_jax/tree_util.py
@@ -122,6 +122,36 @@ def _merge_path(
     return explicit_path, None
 
 
+def live_jvp_output_positions(
+    output_pytreedef: PyTreeDef,
+    n_outputs: int,
+    diff_output_paths: dict[str, Any],
+    live_output_paths: tuple[str, ...] | None,
+) -> list[int]:
+    """Output-leaf positions a ``jacobian_vector_product`` bind should emit.
+
+    Positions are returned in ``output_avals`` order so that abstract_eval, the
+    endpoint wrapper and the DCE rule all agree on the layout. A leaf is kept
+    when it is non-differentiable (its tangent is a cheap NaN and cannot be named
+    by a path) or when its differentiable path is in ``live_output_paths``.
+    ``live_output_paths is None`` means "keep everything" (the un-pruned default,
+    e.g. when DCE never ran).
+
+    This is the single source of truth shared by ``abstract_eval`` (which sizes
+    the primitive's outputs) and ``Jaxeract.jacobian_vector_product`` (which
+    assembles them); keeping them in lock-step is what makes pruning safe.
+    """
+    output_flat = _pytree_to_tesseract_flat(
+        jax.tree.unflatten(output_pytreedef, range(n_outputs)),
+        schema_paths=diff_output_paths,
+    )
+    positions = []
+    for pos, (path, is_diff) in enumerate(output_flat.items()):
+        if is_diff is None or live_output_paths is None or path in live_output_paths:
+            positions.append(pos)
+    return positions
+
+
 def _pytree_to_tesseract_flat(
     pytree: PyTree, schema_paths: dict[str, Any] | None = None
 ) -> dict[str, Any]:

--- a/tests/test_endtoend.py
+++ b/tests/test_endtoend.py
@@ -756,6 +756,57 @@ def test_partial_differentiation(served_univariate_tesseract_raw, use_jit):
     _assert_pytree_isequal(grad, grad_ref)
 
 
+@pytest.mark.parametrize("use_jit", [True, False])
+def test_partial_differentiation_jvp(
+    served_pytree_tesseract, pytree_tess_inputs, use_jit, monkeypatch
+):
+    """``jax.jvp`` restricts what the ``jacobian_vector_product`` endpoint computes.
+
+    Differentiates one output (``result``) wrt one input (``alpha.x``) of a
+    multi-in / multi-out served Tesseract:
+
+    - ``jvp_inputs`` is restricted in *both* modes (trace-time ``has_tangent``
+      filtering, not DCE).
+    - ``jvp_outputs`` is restricted only under ``jit``, where DCE prunes the dead
+      output tangents. We deliberately do not assert the un-jitted output set, so
+      this test would not regress if JAX ever began running DCE without ``jit``.
+    """
+    tess = Tesseract.from_url(served_pytree_tesseract)
+    inp = jax.tree.map(jnp.asarray, pytree_tess_inputs)
+    x = inp["alpha"]["x"]
+    t = jnp.ones_like(x)
+
+    def f(x):
+        full = {**inp, "alpha": {**inp["alpha"], "x": x}}
+        return apply_tesseract(tess, full)["result"]
+
+    calls: list[dict] = []
+    orig = tess.jacobian_vector_product
+
+    def spy(*, inputs, jvp_inputs, jvp_outputs, tangent_vector):
+        calls.append({"inputs": sorted(jvp_inputs), "outputs": sorted(jvp_outputs)})
+        return orig(
+            inputs=inputs,
+            jvp_inputs=jvp_inputs,
+            jvp_outputs=jvp_outputs,
+            tangent_vector=tangent_vector,
+        )
+
+    # Un-jitted reference for the value check (computed before the spy so only the
+    # measured call is captured).
+    _, ref = jax.jvp(f, (x,), (t,))
+    monkeypatch.setattr(tess, "jacobian_vector_product", spy)
+
+    jvp_fn = jax.jit(lambda x, t: jax.jvp(f, (x,), (t,))[1]) if use_jit else None
+    out = jvp_fn(x, t) if use_jit else jax.jvp(f, (x,), (t,))[1]
+
+    np.testing.assert_allclose(np.asarray(out), np.asarray(ref), rtol=1e-5)
+    assert calls, "expected the jvp endpoint to be called"
+    assert calls[-1]["inputs"] == ["alpha.{x}"]
+    if use_jit:
+        assert calls[-1]["outputs"] == ["result"]
+
+
 def test_tesseract_as_jax_pytree(served_univariate_tesseract_raw):
     """Test that Tesseract can be used as a JAX PyTree."""
     tess = Tesseract.from_url(served_univariate_tesseract_raw)

--- a/tests/test_jacobian_batching.py
+++ b/tests/test_jacobian_batching.py
@@ -495,6 +495,75 @@ def test_jitted_jacfwd_partial_diff_restrictions(
 
 
 @pytest.mark.parametrize("use_jit", [True, False])
+def test_jacfwd_of_tangent_fn_prunes_like_jacfwd(
+    pytree_tess, pytree_tess_inputs, use_jit, monkeypatch
+):
+    """Differentiating a linearized function requests only the live sub-block.
+
+    The batching rule has to honour the equation's ``live_output_paths`` for this:
+    it recomputes the requested rows from the schema, so without threading the
+    pruning through it would request every differentiable row -- and, worse, report
+    a different output count than ``abstract_eval`` does for the same bind.
+
+    The pruning holds whether or not this is jitted, because ``jax.linearize``
+    partially evaluates and bakes it into the tangent function's jaxpr before DCE
+    is ever asked. That makes the linearized path *narrower* than ``jacfwd(f)``
+    un-jitted, where forward-mode DCE does not run -- hence the assertion is on
+    the requested block itself rather than parity with the reference.
+    """
+    inp = jax.tree.map(jnp.asarray, pytree_tess_inputs)
+    alpha, delta = inp["alpha"], inp["delta"]
+
+    def f(alpha, delta):
+        # Consumes one of several differentiable outputs.
+        return apply_tesseract(pytree_tess, {**inp, "alpha": alpha, "delta": delta})[
+            "result"
+        ]
+
+    # One spy for both phases -- stacking two would make the first also record the
+    # second's calls.
+    seen: list[tuple] = []
+    orig = pytree_tess.jacobian
+
+    def spy(*, inputs, jac_inputs, jac_outputs):
+        seen.append((tuple(sorted(jac_inputs)), tuple(sorted(jac_outputs))))
+        return orig(inputs=inputs, jac_inputs=jac_inputs, jac_outputs=jac_outputs)
+
+    monkeypatch.setattr(pytree_tess, "jacobian", spy)
+
+    def maybe_jit(fn):
+        return jax.jit(fn) if use_jit else fn
+
+    expected = maybe_jit(jax.jacfwd(f, argnums=0))(alpha, delta)
+    reference_requests = list(seen)
+    seen.clear()
+
+    _primal, tangent_fn = jax.linearize(f, alpha, delta)
+    got = maybe_jit(jax.jacfwd(tangent_fn, argnums=0))(alpha, delta)
+    linearized_requests = list(seen)
+
+    jax.tree.map(
+        lambda a, b: np.testing.assert_allclose(a, b, rtol=1e-5), expected, got
+    )
+    # One jacobian call, restricted to the differentiated argument's columns and
+    # the single consumed output's row. `delta` is not differentiated, so none of
+    # its columns appear; `result_dict` / `result_list` are not consumed, so none
+    # of their rows do.
+    assert linearized_requests == [(("alpha.{x}", "alpha.{y}"), ("result",))], (
+        f"linearized path requested {linearized_requests}"
+    )
+    # Under jit the reference prunes identically; un-jitted it cannot, so it asks
+    # for every differentiable row.
+    if use_jit:
+        assert reference_requests == linearized_requests
+    else:
+        assert reference_requests != linearized_requests, (
+            "expected un-jitted jacfwd(f) to request more rows than the "
+            "linearized path, since forward-mode DCE does not run eagerly"
+        )
+
+
+@pytest.mark.parametrize("use_jit", [True, False])
 def test_matches_jacrev_on_pure_jax(vectoradd_tess, use_jit, monkeypatch):
     """The shortcut's numerical result matches a pure-JAX implementation."""
     a = jnp.array([1.0, 2.0, 3.0], dtype="float32")

--- a/tests/test_jacobian_batching.py
+++ b/tests/test_jacobian_batching.py
@@ -330,8 +330,15 @@ def test_batched_jvp_dtype_matches_jax_convention(mixed_dtype_tess):
     )
 
 
-def test_jacfwd_partial_diff_restricts_jac_inputs(univariate_tess, monkeypatch):
-    """``jacfwd`` wrt one of several diff inputs requests only that column."""
+@pytest.mark.parametrize("use_jit", [False, True])
+def test_jacfwd_partial_diff_restricts_jac_inputs(
+    univariate_tess, use_jit, monkeypatch
+):
+    """``jacfwd`` wrt one of several diff inputs requests only that column.
+
+    Input restriction is trace-time (``has_tangent`` filtering, not DCE), so it
+    holds jitted and un-jitted alike.
+    """
     x = jnp.array(1.0, dtype="float64")
     y = jnp.array(2.0, dtype="float64")
 
@@ -348,7 +355,8 @@ def test_jacfwd_partial_diff_restricts_jac_inputs(univariate_tess, monkeypatch):
         return orig(inputs=inputs, jac_inputs=jac_inputs, jac_outputs=jac_outputs)
 
     monkeypatch.setattr(univariate_tess, "jacobian", spy)
-    g = jax.jacfwd(f)(x)
+    jac_fn = jax.jit(jax.jacfwd(f)) if use_jit else jax.jacfwd(f)
+    g = jac_fn(x)
 
     np.testing.assert_allclose(g, -400.0, rtol=1e-5)
     assert captured["jac_inputs"] == ["x"], (
@@ -356,7 +364,10 @@ def test_jacfwd_partial_diff_restricts_jac_inputs(univariate_tess, monkeypatch):
     )
 
 
-def test_jacrev_partial_diff_restricts_jac_inputs(univariate_tess, monkeypatch):
+@pytest.mark.parametrize("use_jit", [False, True])
+def test_jacrev_partial_diff_restricts_jac_inputs(
+    univariate_tess, use_jit, monkeypatch
+):
     """``jacrev`` wrt one of several diff inputs requests only that column."""
     x = jnp.array(1.0, dtype="float64")
     y = jnp.array(2.0, dtype="float64")
@@ -372,7 +383,8 @@ def test_jacrev_partial_diff_restricts_jac_inputs(univariate_tess, monkeypatch):
         return orig(inputs=inputs, jac_inputs=jac_inputs, jac_outputs=jac_outputs)
 
     monkeypatch.setattr(univariate_tess, "jacobian", spy)
-    g = jax.jacrev(f)(x)
+    jac_fn = jax.jit(jax.jacrev(f)) if use_jit else jax.jacrev(f)
+    g = jac_fn(x)
 
     np.testing.assert_allclose(g, -400.0, rtol=1e-5)
     assert captured["jac_inputs"] == ["x"]
@@ -409,6 +421,77 @@ def test_jacfwd_of_tangent_fn_restricts_jac_inputs(univariate_tess, monkeypatch)
     assert captured["jac_inputs"] == ["x"], (
         f"expected only 'x' to be requested, got {captured['jac_inputs']}"
     )
+
+
+@pytest.mark.parametrize("materialize_jacobian", [None, False])
+def test_jitted_jacfwd_partial_diff_restrictions(
+    pytree_tess, pytree_tess_inputs, materialize_jacobian, monkeypatch
+):
+    """Under ``jit``, ``jacfwd`` requests only the live (input, output) sub-block.
+
+    Differentiates one output (``result``) wrt one input (``alpha.x``) of a
+    multi-in / multi-out Tesseract and checks the request is pruned on *both*
+    forward code paths: the materialised ``jacobian`` endpoint
+    (``materialize_jacobian=None``) and the per-tangent
+    ``jacobian_vector_product`` endpoint (``materialize_jacobian=False``).
+
+    Output restriction relies on DCE, which only runs under ``jit`` — hence the
+    ``jax.jit`` wrapper here (cf. the un-jitted input tests above).
+    """
+    inp = jax.tree.map(jnp.asarray, pytree_tess_inputs)
+    x = inp["alpha"]["x"]
+
+    def f(x):
+        full = {**inp, "alpha": {**inp["alpha"], "x": x}}
+        return apply_tesseract(
+            pytree_tess,
+            full,
+            vmap_method="sequential",
+            materialize_jacobian=materialize_jacobian,
+        )["result"]
+
+    jac: dict[str, list] = {"inputs": [], "outputs": []}
+    jvp: dict[str, list] = {"inputs": [], "outputs": []}
+    orig_jac = pytree_tess.jacobian
+    orig_jvp = pytree_tess.jacobian_vector_product
+
+    def spy_jac(*, inputs, jac_inputs, jac_outputs):
+        jac["inputs"].append(sorted(jac_inputs))
+        jac["outputs"].append(sorted(jac_outputs))
+        return orig_jac(inputs=inputs, jac_inputs=jac_inputs, jac_outputs=jac_outputs)
+
+    def spy_jvp(*, inputs, jvp_inputs, jvp_outputs, tangent_vector):
+        jvp["inputs"].append(sorted(jvp_inputs))
+        jvp["outputs"].append(sorted(jvp_outputs))
+        return orig_jvp(
+            inputs=inputs,
+            jvp_inputs=jvp_inputs,
+            jvp_outputs=jvp_outputs,
+            tangent_vector=tangent_vector,
+        )
+
+    # Un-jitted reference for the value check (DCE off -> full request, but the
+    # selected `result` block is identical). Computed before the spies are set so
+    # only the jitted, pruned call is captured below.
+    ref = jax.jacfwd(f)(x)
+
+    monkeypatch.setattr(pytree_tess, "jacobian", spy_jac)
+    monkeypatch.setattr(pytree_tess, "jacobian_vector_product", spy_jvp)
+    out = jax.jit(jax.jacfwd(f))(x)
+
+    np.testing.assert_allclose(out, ref, rtol=1e-5)
+
+    if materialize_jacobian is None:
+        assert jvp["outputs"] == [], "materialised path must not call the jvp endpoint"
+        assert jac["inputs"] == [["alpha.{x}"]]
+        assert jac["outputs"] == [["result"]]
+    else:
+        assert jac["outputs"] == [], (
+            "per-tangent path must not call the jacobian endpoint"
+        )
+        assert jvp["outputs"], "expected the jvp endpoint to be called"
+        assert all(o == ["result"] for o in jvp["outputs"]), jvp["outputs"]
+        assert all(i == ["alpha.{x}"] for i in jvp["inputs"]), jvp["inputs"]
 
 
 @pytest.mark.parametrize("use_jit", [True, False])


### PR DESCRIPTION
<!--
Please use a PR title that conforms to *conventional commits*: "<commit_type>: Describe your change"; for example: "fix: prevent race condition". Some other commit types are: fix, feat, ci, doc, refactor...
For a full list of commit types visit https://www.conventionalcommits.org/en/v1.0.0/
-->

#### Relevant issue or PR

- #191 

#### Description of changes

Tesseracts' `jacobian_vector_product` and `jacobian` endpoints support partial differential through `jvp_outputs` and `jac_outputs` which can reduce both the amount of computation the Tesseract does and the size of the output they return. Currently we don't leverage this in tesseract-jax because by default JAX's jvp rules are expected to produce tangents wrt all outputs. For jacobians particularly this can lead to much higher computation and memory flow than optimal. However, JAX offers a primitive ruleset for partial evaluation called `dce_rules` which allows us to leverage the fact that JAX knows which outputs are "dead" and never referenced and which are genuinely required. This PR attempts to leverage these to provide `jvp_outputs` and `jac_outputs` to the Tesseract.

@dionhaefner this is still a draft while I try get my head fully round it and neaten it up a bit, but I wanted to share here as it might affect whether we can to wait for this before the next release.

#### Testing done

Needs a lot more testing still.