### PR TITLE
chore: fix bump workflow lockfile generation

### DIFF
--- a/.github/workflows/bump_lockfile.yml
+++ b/.github/workflows/bump_lockfile.yml
@@ -19,20 +19,20 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version-file: "pyproject.toml"
+      - name: Install pre-commit
+        # uv provides the interpreter and puts pre-commit on PATH for the steps
+        # below.
+        run: |
+          uv tool install pre-commit
 
       - name: Update lockfile
         run: |
-          mv production.uv.lock uv.lock
-          uv lock --upgrade
-          mv uv.lock production.uv.lock
+          # Remove lockfile to force update
+          rm production.uv.lock
+          pre-commit run update-uv-env --all-files || true
 
       - name: Generate new requirements.txt
         run: |
-          pip install pre-commit
           pre-commit run update-requirements --all-files || true
 
       - name: Detect if changes were made


### PR DESCRIPTION
## Problem

The `Bump UV lockfile` workflow regenerated `production.uv.lock` directly with the workflow's uv (`astral-sh/setup-uv@v7`), while the `update-uv-env` pre-commit hook that CI validates against pins `uv==0.11.21`. uv 0.11.26 changed how platform markers are emitted, so the bot-committed lockfile and the CI-regenerated one differed, failing the `pre-commit` check on bump PRs.

## Fix

Adopt the same approach the internal repos already use: remove `production.uv.lock` and regenerate it through the pinned pre-commit hooks, instead of calling `uv lock` with the workflow's own uv. Bot and CI now use the same uv version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)