### PR TITLE
fix: guard transpose rule against UndefinedPrimal

### DIFF
--- a/tesseract_jax/primitive.py
+++ b/tesseract_jax/primitive.py
@@ -233,7 +233,7 @@ ad.primitive_jvps[tesseract_dispatch_p] = tesseract_dispatch_jvp_rule
 
 def tesseract_dispatch_transpose_rule(
     cotangent: Sequence[ArrayLike | ad.Zero],
-    *args: ArrayLike,
+    *args: ArrayLike | ad.UndefinedPrimal,
     static_args: tuple[_Hashable, ...],
     input_pytreedef: PyTreeDef,
     output_pytreedef: PyTreeDef,
@@ -250,6 +250,22 @@ def tesseract_dispatch_transpose_rule(
 
     n_primals = len(is_static_mask) - sum(is_static_mask)
     primal_args = args[:n_primals]
+
+    # Primal slots must hold concrete residuals. An UndefinedPrimal here means the
+    # caller asked us to transpose with respect to a primal -- J(x)·v is linear in
+    # the tangent v but not in x, so no endpoint can serve it. JAX itself refuses
+    # the equivalent transpose, so bail with guidance instead of letting the
+    # UndefinedPrimal fall through into the checks below.
+    if any(ad.is_undefined_primal(p) for p in primal_args):
+        raise ValueError(
+            "Transpose of the Tesseract primitive requires concrete primal "
+            "values, but received UndefinedPrimal. This typically happens when "
+            "jax.linear_transpose is applied to a function whose arguments "
+            "include both primals and tangents. Close over the primals instead, "
+            "e.g.:\n"
+            "  primals = (x,)\n"
+            "  jax.linear_transpose(lambda t: jax.jvp(f, primals, (t,))[1], x)"
+        )
 
     # Raise if a cotangent for a non-differentiable output is not a symbolic zero.
     # Symbolic zeros (ad.Zero) are produced by JAX when gradients are blocked

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -1,0 +1,140 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for jax.linearize and jax.linear_transpose with tesseract-jax.
+
+All tests use the (nonlinear) Rosenbrock tesseract: a linear tesseract makes
+the Jacobian the identity, which renders most assertions here tautological.
+
+Every test is parametrised over ``use_jit`` because the two settings dispatch
+through separately registered code paths -- ``tesseract_dispatch_p.def_impl``
+when eager, ``mlir.register_lowering`` when staged out -- so a change can break
+one without the other.
+"""
+
+import jax
+import numpy as np
+import pytest
+
+from tesseract_jax import apply_tesseract
+
+# ---------------------------------------------------------------------------
+# jax.linearize
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_jit", [True, False])
+def test_linearize_univariate(univariate_tess, use_jit):
+    """jax.linearize on the Rosenbrock tesseract, check tangent_fn matches JVP."""
+    x = np.array(1.0, dtype="float64")
+    y = np.array(2.0, dtype="float64")
+
+    def f(x):
+        return apply_tesseract(univariate_tess, inputs=dict(x=x, y=y))["result"]
+
+    if use_jit:
+        f = jax.jit(f)
+
+    _primal_out, tangent_fn = jax.linearize(f, x)
+
+    # Compare tangent_fn with jax.jvp
+    t = np.array(1.0, dtype="float64")
+    tangent_out = tangent_fn(t)
+
+    _, jvp_out = jax.jvp(f, (x,), (t,))
+    np.testing.assert_allclose(tangent_out, jvp_out, rtol=1e-5)
+
+    # Linearity check
+    t2 = np.array(3.0, dtype="float64")
+    np.testing.assert_allclose(
+        tangent_fn(t + t2), tangent_fn(t) + tangent_fn(t2), rtol=1e-5
+    )
+
+
+# ---------------------------------------------------------------------------
+# jax.linear_transpose
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_jit", [True, False])
+def test_linear_transpose_univariate(univariate_tess, use_jit):
+    """linear_transpose of the linearized tangent function matches VJP."""
+    x = np.array(1.0, dtype="float64")
+    y = np.array(2.0, dtype="float64")
+
+    def f(x):
+        return apply_tesseract(univariate_tess, inputs=dict(x=x, y=y))["result"]
+
+    if use_jit:
+        f = jax.jit(f)
+
+    _primal_out, tangent_fn = jax.linearize(f, x)
+
+    transpose_fn = jax.linear_transpose(tangent_fn, x)
+
+    ct = np.array(1.0, dtype="float64")
+    (transposed,) = transpose_fn(ct)
+
+    # Compare with VJP
+    _, vjp_fn = jax.vjp(f, x)
+    (vjp_result,) = vjp_fn(ct)
+    np.testing.assert_allclose(transposed, vjp_result, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# UndefinedPrimal guard in the transpose rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_jit", [True, False])
+def test_linear_transpose_on_raw_jvp_without_closure(univariate_tess, use_jit):
+    """linear_transpose on jvp_fun(primals, tangents) is rejected.
+
+    When primals are NOT closed over, JAX leaves them as UndefinedPrimal
+    residuals when the transpose rule fires — transposing with respect to a
+    primal is not linear, so there is nothing sensible to dispatch. Tracing
+    succeeds; calling the transposed function raises a guidance ValueError.
+    """
+    x = np.array(1.0, dtype="float64")
+    y = np.array(2.0, dtype="float64")
+
+    def f(x):
+        return apply_tesseract(univariate_tess, inputs=dict(x=x, y=y))["result"]
+
+    if use_jit:
+        f = jax.jit(f)
+
+    def jvp_fun(primals, tangents):
+        return jax.jvp(f, (primals,), (tangents,))[1]
+
+    transpose_fn = jax.linear_transpose(jvp_fun, x, x)
+    ct = np.array(1.0, dtype="float64")
+    with pytest.raises(ValueError, match=r"(?i)UndefinedPrimal"):
+        transpose_fn(ct)
+
+
+@pytest.mark.parametrize("use_jit", [True, False])
+def test_linear_transpose_on_raw_jvp_with_closure(univariate_tess, use_jit):
+    """The workaround the guard's error message recommends must actually work.
+
+    Closing over the primals leaves the function linear in its tangent argument
+    alone, so the transpose is well defined and agrees with the VJP.
+    """
+    x = np.array(1.0, dtype="float64")
+    y = np.array(2.0, dtype="float64")
+
+    def f(x):
+        return apply_tesseract(univariate_tess, inputs=dict(x=x, y=y))["result"]
+
+    if use_jit:
+        f = jax.jit(f)
+
+    primals = (x,)
+    transpose_fn = jax.linear_transpose(lambda t: jax.jvp(f, primals, (t,))[1], x)
+
+    ct = np.array(1.0, dtype="float64")
+    (transposed,) = transpose_fn(ct)
+
+    _, vjp_fn = jax.vjp(f, x)
+    (vjp_result,) = vjp_fn(ct)
+    np.testing.assert_allclose(transposed, vjp_result, rtol=1e-5)


### PR DESCRIPTION
#### Description of changes

Right now if a user did the following:

```python
def f(x):
    return apply_tesseract(univariate_tess, dict(x=x, y=y))["result"]

def jvp_fun(primals, tangents):
    return jax.jvp(f, (primals,), (tangents,))[1]

jax.linear_transpose(jvp_fun, x, x)(ct)
```

They'd get the following error:

```
ValueError: zip() argument 2 is longer than argument 1
  File "tesseract_jax/primitive.py", line 280, in tesseract_dispatch_transpose_rule
    p for p, m in zip(_flat_inputs, is_static_mask, strict=True) if not m
```

And if a dev wrote a test including this with typeguard on they'd get:

```
typeguard.TypeCheckError: item 0 of argument "args" (tuple) did not match any element in the union:
  jax.Array: is not an instance of jax.Array
  numpy.ndarray: is not an instance of numpy.ndarray
  numpy.bool: is not an instance of numpy.bool
  numpy.number: is not an instance of numpy.number
  bool: is not an instance of bool
  int: is not an instance of int
  float: is neither float or int
  complex: is neither complex, float or int
```

Both are opaque and unhelpful, this PR rewords the error message to the following:

```
ValueError: Transpose of the Tesseract primitive requires concrete primal values,
but received UndefinedPrimal. This typically happens when jax.linear_transpose is
applied to a function whose arguments include both primals and tangents. Close over
the primals instead, e.g.:
  primals = (x,)
  jax.linear_transpose(lambda t: jax.jvp(f, primals, (t,))[1], x)
```

The cause is that transposing with respect to a primal isn't linear, so no endpoint can serve it. Plain JAX refuses the equivalent transpose too, so this is parity rather than a tesseract-jax limitation.

The transpose rule's signature is widened to `ArrayLike | ad.UndefinedPrimal` — without that, typeguard rejects the argument before the guard can run, which is why the tests would otherwise need `suppress_type_checks()`.

#### Testing done

Adds tests for `jax.linearize` and `jax.linear_transpose` against `apply_tesseract`, which had no coverage: the guard itself, the closure-over-primals workaround the message recommends, `linearize`'s tangent function matching `jax.jvp`, and `linear_transpose` of it matching `jax.vjp`. All parametrised over `use_jit`, since eager and staged dispatch go through separately registered code paths (`tesseract_dispatch_p.def_impl` vs `mlir.register_lowering`).

Both error messages above were reproduced against this PR's base (312bdf7). Reverting the guard fails exactly the test that covers it and nothing else. Full suite green.
