### PR TITLE
feat: support differentiating Tesseract derivative endpoints wrt (co)tangents

### DIFF
--- a/tesseract_jax/primitive.py
+++ b/tesseract_jax/primitive.py
@@ -46,6 +46,14 @@ class _Hashable:
             return id(self.wrapped)
 
 
+def _instantiate_zeros(tangents: Sequence[Any]) -> tuple[ArrayLike, ...]:
+    """Densify symbolic zeros, which cannot be passed to ``bind`` as-is."""
+    return tuple(
+        jax.numpy.zeros_like(t.aval) if isinstance(t, jax._src.ad_util.Zero) else t
+        for t in tangents
+    )
+
+
 @tesseract_dispatch_p.def_abstract_eval
 def tesseract_dispatch_abstract_eval(
     *array_args: ArrayLike | ShapedArray,
@@ -152,8 +160,8 @@ def tesseract_dispatch_jvp_rule(
     reverse-mode autodiff.
 
     """
-    if eval_func != "apply":
-        raise RuntimeError("Cannot take higher-order derivatives")
+    if eval_func not in ("apply", "jacobian_vector_product", "vector_jacobian_product"):
+        raise RuntimeError(f"Cannot take higher-order derivatives of {eval_func!r}")
 
     #  https://github.com/jax-ml/jax/issues/16303#issuecomment-1585295819
     #  mattjj: taking a narrow pigeon-holed view, anywhere you see a symbolic
@@ -161,52 +169,84 @@ def tesseract_dispatch_jvp_rule(
     #          (not in ad.py's backward_pass), you probably want to instantiate
     #          it so that it's no longer symbolic
 
-    # Compute which primals have non-zero tangents
-    has_tangent = tuple(
-        not (isinstance(t, jax._src.ad_util.Zero) or t is None) for t in tan_args
-    )
+    n_primals = len(is_static_mask) - sum(is_static_mask)
 
-    # Raise if a non-symbolic-zero tangent is provided for a non-differentiable input.
-    _tangents_for_check = tuple(
-        t if h else None for t, h in zip(tan_args, has_tangent, strict=True)
-    )
-    _tangent_inputs = unflatten_args(
-        _tangents_for_check,
-        static_args,
-        input_pytreedef,
-        is_static_mask,
-        remove_static_args=True,
-    )
-    _flat_tangents = _pytree_to_tesseract_flat(
-        _tangent_inputs, schema_paths=client.differentiable_input_paths
-    )
-    for path, val in _flat_tangents.items():
-        if val is None:
-            raise ValueError(
-                f"Non-symbolic-zero tangent provided for non-differentiable input '{path}'. "
-                f"If this input should be differentiable, mark it as "
-                f"`Differentiable[...]` in the Tesseract input schema. Otherwise, "
-                f"exclude it from the differentiated function's argument list "
-                f"(using a closure or the `argnums` parameter), or apply "
-                f"jax.lax.stop_gradient to it before passing to apply_tesseract."
+    if eval_func == "apply":
+        # Compute which primals have non-zero tangents
+        has_tangent = tuple(not isinstance(t, jax._src.ad_util.Zero) for t in tan_args)
+
+        # Raise if a non-symbolic-zero tangent is provided for a non-differentiable input.
+        _tangents_for_check = tuple(
+            t if h else None for t, h in zip(tan_args, has_tangent, strict=True)
+        )
+        _tangent_inputs = unflatten_args(
+            _tangents_for_check,
+            static_args,
+            input_pytreedef,
+            is_static_mask,
+            remove_static_args=True,
+        )
+        _flat_tangents = _pytree_to_tesseract_flat(
+            _tangent_inputs, schema_paths=client.differentiable_input_paths
+        )
+        for path, val in _flat_tangents.items():
+            if val is None:
+                raise ValueError(
+                    f"Non-symbolic-zero tangent provided for non-differentiable input '{path}'. "
+                    f"If this input should be differentiable, mark it as "
+                    f"`Differentiable[...]` in the Tesseract input schema. Otherwise, "
+                    f"exclude it from the differentiated function's argument list "
+                    f"(using a closure or the `argnums` parameter), or apply "
+                    f"jax.lax.stop_gradient to it before passing to apply_tesseract."
+                )
+        # Differentiating `apply` means differentiating wrt its primals.
+        tan_args_ = _instantiate_zeros(tan_args)
+    else:
+        # A derivative endpoint is linear in its (co)tangent slots, so its JVP is
+        # that same endpoint at the new (co)tangents. Its primals are another
+        # matter: that needs a second derivative, which Tesseract does not expose.
+        if not all(isinstance(t, jax._src.ad_util.Zero) for t in tan_args[:n_primals]):
+            raise RuntimeError(
+                "Cannot differentiate a Tesseract derivative endpoint with respect "
+                "to its primal inputs, as this needs a second derivative."
             )
+        tan_args_ = _instantiate_zeros(tan_args[n_primals:])
 
-    tan_args_ = tuple(
-        (jax.numpy.zeros_like(arg.aval) if not has_tan else arg)
-        for arg, has_tan in zip(tan_args, has_tangent, strict=True)
-    )
+    # `has_tangent` describes a bind's own (co)tangent operands, so the derivative
+    # bind below needs one for `tan_args_` rather than the mask it inherited. Only
+    # a `jacobian_vector_product` can have one: its linear slots are tangents, one
+    # per primal, which is how `has_tangent` is indexed. A
+    # `vector_jacobian_product`'s are cotangents, one per output, so they cannot
+    # size such a mask and it keeps the inherited value -- as does `res`, which
+    # reproduces the original call over the original operands.
+    #
+    # Not cosmetic: the batching rule turns `has_tangent` into `jac_input_paths`,
+    # i.e. which columns of the Jacobian get requested, so an inherited mask
+    # over-fetches whenever only some arguments are differentiated.
+    # `jacfwd(lin_fn, argnums=0)` would ask for every column and then multiply the
+    # unwanted ones by the zeros instantiated above.
+    deriv_has_tangent = has_tangent
+    if eval_func == "jacobian_vector_product":
+        deriv_has_tangent = tuple(
+            not isinstance(t, jax._src.ad_util.Zero) for t in tan_args[n_primals:]
+        )
+
     # this leads to an abstract_eval call and a jvp
     jvp = tesseract_dispatch_p.bind(
-        *in_args,
+        *in_args[:n_primals],
         *tan_args_,
         static_args=static_args,
         input_pytreedef=input_pytreedef,
         output_pytreedef=output_pytreedef,
         output_avals=output_avals,
         is_static_mask=is_static_mask,
-        has_tangent=has_tangent,
+        has_tangent=deriv_has_tangent,
         client=client,
-        eval_func="jacobian_vector_product",
+        eval_func=(
+            "vector_jacobian_product"
+            if eval_func == "vector_jacobian_product"
+            else "jacobian_vector_product"
+        ),
         vmap_method=vmap_method,
         materialize_jacobian=materialize_jacobian,
     )
@@ -220,7 +260,7 @@ def tesseract_dispatch_jvp_rule(
         is_static_mask=is_static_mask,
         has_tangent=has_tangent,
         client=client,
-        eval_func="apply",
+        eval_func=eval_func,
         vmap_method=vmap_method,
         materialize_jacobian=materialize_jacobian,
     )
@@ -310,14 +350,7 @@ def tesseract_dispatch_transpose_rule(
                 f"jax.lax.stop_gradient to it before passing to apply_tesseract."
             )
 
-    cotan_args_ = tuple(
-        (
-            jax.numpy.zeros_like(arg.aval)
-            if isinstance(arg, jax._src.ad_util.Zero)
-            else arg
-        )
-        for arg in cotangent
-    )
+    cotan_args_ = _instantiate_zeros(cotangent)
 
     vjp = tesseract_dispatch_p.bind(
         *primal_args,

--- a/tests/test_jacobian_batching.py
+++ b/tests/test_jacobian_batching.py
@@ -22,11 +22,16 @@ from tesseract_jax import apply_tesseract
 
 
 def _spy_endpoints(tess, monkeypatch):
-    """Wrap jacobian / jvp / vjp endpoints with counters."""
-    counts = {"jacobian": 0, "jvp": 0, "vjp": 0}
+    """Wrap apply / jacobian / jvp / vjp endpoints with counters."""
+    counts = {"apply": 0, "jacobian": 0, "jvp": 0, "vjp": 0}
+    orig_apply = tess.apply
     orig_jac = tess.jacobian
     orig_jvp = tess.jacobian_vector_product
     orig_vjp = tess.vector_jacobian_product
+
+    def wa(*a, **kw):
+        counts["apply"] += 1
+        return orig_apply(*a, **kw)
 
     def wj(*a, **kw):
         counts["jacobian"] += 1
@@ -40,6 +45,7 @@ def _spy_endpoints(tess, monkeypatch):
         counts["vjp"] += 1
         return orig_vjp(*a, **kw)
 
+    monkeypatch.setattr(tess, "apply", wa)
     monkeypatch.setattr(tess, "jacobian", wj)
     monkeypatch.setattr(tess, "jacobian_vector_product", wjvp)
     monkeypatch.setattr(tess, "vector_jacobian_product", wvjp)
@@ -111,6 +117,37 @@ def test_jacfwd_through_jit(vectoradd_tess, monkeypatch):
     M = jax.jacfwd(f)(a)
 
     np.testing.assert_allclose(M, np.eye(3, dtype="float32"), atol=1e-6)
+    assert counts["jacobian"] == 1
+    assert counts["jvp"] == 0
+
+
+def test_jacfwd_of_linearized_uses_jacobian_endpoint(vectoradd_tess, monkeypatch):
+    """``jacfwd`` of a ``jax.linearize`` tangent function uses the shortcut too.
+
+    The spy covers the ``linearize`` call as well, so the counts are the whole cost
+    of the pattern: one ``apply`` (the forward evaluation ``linearize`` itself
+    needs, and differentiating the tangent function adds none) plus one
+    ``jacobian`` (the batching shortcut), and no ``jvp`` at all.
+
+    That last one is the interesting part. The JVP rule for a derivative endpoint
+    emits two binds -- the undifferentiated output and the endpoint re-applied at
+    the new tangent -- and ``jacfwd`` discards the former. Under ``jit`` DCE drops
+    it, so this costs exactly what ``jacfwd(f)`` costs. Un-jitted, DCE does not
+    fire and the discarded bind is paid for; hence the ``jit`` here.
+    """
+    a = jnp.array([1.0, 2.0, 3.0], dtype="float32")
+    b = jnp.array([0.5, 0.5, 0.5], dtype="float32")
+
+    def f(a):
+        return apply_tesseract(vectoradd_tess, dict(a=a, b=b))["c"]
+
+    counts = _spy_endpoints(vectoradd_tess, monkeypatch)
+    _primal_out, tangent_fn = jax.linearize(f, a)
+    M = jax.jit(jax.jacfwd(tangent_fn))(a)
+
+    # tangent_fn is linear with f's Jacobian, so this is df/da = I.
+    np.testing.assert_allclose(M, np.eye(3, dtype="float32"), atol=1e-6)
+    assert counts["apply"] == 1
     assert counts["jacobian"] == 1
     assert counts["jvp"] == 0
 
@@ -338,6 +375,39 @@ def test_jacrev_partial_diff_restricts_jac_inputs(univariate_tess, monkeypatch):
 
     np.testing.assert_allclose(g, -400.0, rtol=1e-5)
     assert captured["jac_inputs"] == ["x"]
+
+
+def test_jacfwd_of_tangent_fn_restricts_jac_inputs(univariate_tess, monkeypatch):
+    """``jacfwd`` of a linearized function wrt one argument narrows the request too.
+
+    The tangent function's other argument gets a symbolic-zero tangent, which is
+    instantiated to dense zeros before it can cross a bind. Its Jacobian column
+    would then be fetched only to be multiplied by those zeros, so the JVP rule
+    recomputes ``has_tangent`` for the tangent bind rather than inheriting it.
+    """
+    x = jnp.array(1.0, dtype="float64")
+    y = jnp.array(2.0, dtype="float64")
+
+    def f(x, y):
+        return apply_tesseract(univariate_tess, dict(x=x, y=y))["result"]
+
+    _primal, tangent_fn = jax.linearize(f, x, y)
+    expected = jax.jacfwd(f, argnums=0)(x, y)  # before the spy, so it is not captured
+
+    captured: dict[str, Any] = {}
+    orig = univariate_tess.jacobian
+
+    def spy(*, inputs, jac_inputs, jac_outputs):
+        captured["jac_inputs"] = list(jac_inputs)
+        return orig(inputs=inputs, jac_inputs=jac_inputs, jac_outputs=jac_outputs)
+
+    monkeypatch.setattr(univariate_tess, "jacobian", spy)
+    g = jax.jacfwd(tangent_fn, argnums=0)(x, y)
+
+    np.testing.assert_allclose(g, expected, rtol=1e-5)
+    assert captured["jac_inputs"] == ["x"], (
+        f"expected only 'x' to be requested, got {captured['jac_inputs']}"
+    )
 
 
 @pytest.mark.parametrize("use_jit", [True, False])

--- a/tests/test_linearize.py
+++ b/tests/test_linearize.py
@@ -3,8 +3,9 @@
 
 """Tests for jax.linearize and jax.linear_transpose with tesseract-jax.
 
-All tests use the (nonlinear) Rosenbrock tesseract: a linear tesseract makes
-the Jacobian the identity, which renders most assertions here tautological.
+Tests use the (nonlinear) Rosenbrock tesseract unless they need several
+differentiable inputs: a linear tesseract makes the Jacobian the identity, which
+renders most assertions here tautological.
 
 Every test is parametrised over ``use_jit`` because the two settings dispatch
 through separately registered code paths -- ``tesseract_dispatch_p.def_impl``
@@ -138,3 +139,117 @@ def test_linear_transpose_on_raw_jvp_with_closure(univariate_tess, use_jit):
     _, vjp_fn = jax.vjp(f, x)
     (vjp_result,) = vjp_fn(ct)
     np.testing.assert_allclose(transposed, vjp_result, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Differentiating a derivative endpoint
+#
+# J(x)·v is linear in v, so jax.jvp / jax.jacfwd of a jax.linearize tangent
+# function is well defined and reduces to the same endpoint at a new tangent.
+# Differentiating with respect to x is not, and must stay refused.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_jit", [True, False])
+def test_jvp_of_tangent_fn(univariate_tess, use_jit):
+    """jax.jvp of a linearized function: both outputs are the endpoint re-applied."""
+    x = np.array(1.0, dtype="float64")
+    y = np.array(2.0, dtype="float64")
+    t = np.array(3.0, dtype="float64")
+
+    def f(x):
+        return apply_tesseract(univariate_tess, inputs=dict(x=x, y=y))["result"]
+
+    if use_jit:
+        f = jax.jit(f)
+
+    _primal_out, tangent_fn = jax.linearize(f, x)
+    primal_out, tangent_out = jax.jvp(tangent_fn, (x,), (t,))
+
+    # tangent_fn is linear, so its JVP is itself evaluated at the new tangent.
+    np.testing.assert_allclose(primal_out, tangent_fn(x), rtol=1e-5)
+    np.testing.assert_allclose(tangent_out, tangent_fn(t), rtol=1e-5)
+
+
+@pytest.mark.parametrize("mode", ["fwd", "rev"])
+@pytest.mark.parametrize("use_jit", [True, False])
+def test_jacobian_of_tangent_fn(univariate_tess, use_jit, mode):
+    """jacfwd/jacrev of a linearized function recovers f's Jacobian.
+
+    This is the pattern optimistix uses.
+    """
+    x = np.array(1.0, dtype="float64")
+    y = np.array(2.0, dtype="float64")
+
+    def f(x):
+        return apply_tesseract(univariate_tess, inputs=dict(x=x, y=y))["result"]
+
+    if use_jit:
+        f = jax.jit(f)
+
+    jac = jax.jacfwd if mode == "fwd" else jax.jacrev
+    _primal_out, tangent_fn = jax.linearize(f, x)
+
+    # d/dv [J(x)·v] == J(x)
+    np.testing.assert_allclose(jac(tangent_fn)(x), jac(f)(x), rtol=1e-5)
+
+
+@pytest.mark.parametrize("use_jit", [True, False])
+def test_jvp_of_vjp_fn(univariate_tess, use_jit):
+    """The VJP endpoint is likewise linear, in its cotangent slots."""
+    x = np.array(1.0, dtype="float64")
+    y = np.array(2.0, dtype="float64")
+    ct = np.array(1.0, dtype="float64")
+    dct = np.array(3.0, dtype="float64")
+
+    def f(x):
+        return apply_tesseract(univariate_tess, inputs=dict(x=x, y=y))["result"]
+
+    if use_jit:
+        f = jax.jit(f)
+
+    _primal_out, vjp_fn = jax.vjp(f, x)
+    primal_out, tangent_out = jax.jvp(vjp_fn, (ct,), (dct,))
+
+    np.testing.assert_allclose(primal_out[0], vjp_fn(ct)[0], rtol=1e-5)
+    np.testing.assert_allclose(tangent_out[0], vjp_fn(dct)[0], rtol=1e-5)
+
+
+@pytest.mark.parametrize("argnums", [0, 1])
+def test_jacfwd_of_tangent_fn_partial_argnums(pytree_tess, pytree_tess_inputs, argnums):
+    """Differentiating only some arguments leaves the rest symbolically zero.
+
+    Uses a multi-differentiable-input tesseract so that some tangent slots arrive
+    as ad.Zero and have to be instantiated before they can cross a bind.
+    """
+    inp = pytree_tess_inputs
+
+    def f(alpha, delta):
+        return apply_tesseract(
+            pytree_tess, inputs={**inp, "alpha": alpha, "delta": delta}
+        )["result"]
+
+    alpha, delta = inp["alpha"], inp["delta"]
+    _primal_out, tangent_fn = jax.linearize(f, alpha, delta)
+
+    expected = jax.jacfwd(f, argnums=argnums)(alpha, delta)
+    got = jax.jacfwd(tangent_fn, argnums=argnums)(alpha, delta)
+    jax.tree.map(
+        lambda a, b: np.testing.assert_allclose(a, b, rtol=1e-5), expected, got
+    )
+
+
+@pytest.mark.parametrize("use_jit", [True, False])
+def test_second_derivative_wrt_primals_is_refused(univariate_tess, use_jit):
+    """A Hessian needs a second derivative, which Tesseract does not expose."""
+    x = np.array(1.0, dtype="float64")
+    y = np.array(2.0, dtype="float64")
+
+    def f(x):
+        return apply_tesseract(univariate_tess, inputs=dict(x=x, y=y))["result"]
+
+    if use_jit:
+        f = jax.jit(f)
+
+    with pytest.raises(RuntimeError, match=r"(?i)primal inputs"):
+        jax.jacfwd(jax.grad(f))(x)


### PR DESCRIPTION
#### Description of changes

`jacobian_vector_product` and `vector_jacobian_product` are linear wrt their provided (co)tangent vectors. This means that it is never _necessary_ to differentiate these endpoints wrt their (co)tangent vectors (one can just evaluate at the new (co)tangent vector instead and get the right answer), but some packages do this anyway, largely for the sake of convenience rather than performance. For example, optimistix's `lin_to_grad` [helper](https://github.com/patrick-kidger/optimistix/blob/6415ab15480ebdb7386e17850105ce0dba6786ec/optimistix/_misc.py#L245-L258) uses the following pattern to create a gradient from a linear function with no transpose rule:

```python
f_eval, lin_fn, aux_eval = jax.linearize(lambda _y: fn(_y, args), state.y_eval, has_aux=True)
jax.jacfwd(lin_fn)(y_eval)
```

However, if `fn` involves a Tesseract, tesseract-jax will raise a `RuntimeError: Cannot take higher-order derivatives`. By telling tesseract-jax that `jacobian_vector_product` and `vector_jacobian_product` are linear wrt their (co)tangents we can relax this and just tell JAX to re-evaluate the endpoint with the batched tangent vectors. This is exactly what this PR does, and moreover in this specific case `jacobian_vector_product` is NEVER evaluated (given `materialise_jacobian=True`), we only need one `apply` call and one `jacobian` call, JAX DCE's the "primal" `jacobian_vector_product` automatically.

#### Testing done

Added tests to ensure the desired behaviour is provided including monitoring endpoint invocations to track DCE.