### PR TITLE
perf: enable CSE with `has_side_effect=False`

### DIFF
--- a/docs/content/get-started.md
+++ b/docs/content/get-started.md
@@ -101,16 +101,18 @@ When creating a new Tesseract based on a JAX function, use `tesseract init --rec
 - **Tesseracts are assumed pure functions** of their inputs. Tesseract-JAX lowers each
   endpoint call as a pure operation, which is what allows repeated identical calls to be
   collapsed into a single request. Where purity does not hold, the compiler is free to
-  surprise you:
+  surprise you. All of the following require compilation, so they apply under
+  `jax.jit` (including anything jitted internally) and never to eager execution, where
+  each call runs as soon as it is reached:
   - **A call whose result is provably unused may not happen.**
 
     ```python
     @jax.jit
     def unused_result(a):
-        _ = apply_tesseract(tess, inputs)["c"]   # not called: nothing depends on it
+        _ = apply_tesseract(tess, inputs)["c"]  # not called: nothing depends on it
         return a * 2.0
 
-    threshold_ok = False   # a concrete value, not a traced argument
+    threshold_ok = False  # a concrete value, not a traced argument
 
     @jax.jit
     def dead_branch():
@@ -118,10 +120,10 @@ When creating a new Tesseract based on a JAX function, use `tesseract init --rec
         return jnp.where(threshold_ok, apply_tesseract(tess, inputs)["c"], 0.0)
     ```
 
-    If the endpoint has an observable side effect — writing a file, logging to a
-    tracking server — that side effect will not happen either, and neither will any
-    error it would have raised. `abstract_eval` is still called while tracing, so a
-    Tesseract that fails abstract validation still fails.
+    If the endpoint has an observable side effect (writing a file, logging to a tracking
+    server), that side effect will not happen either, and neither will any error it
+    would have raised. `abstract_eval` is still called while tracing, so a Tesseract
+    that fails abstract validation still fails.
 
     This cuts both ways: guarding a call you know would be rejected is a legitimate way
     to avoid it, as long as the guard is something the compiler can evaluate. A guard on
@@ -130,9 +132,9 @@ When creating a new Tesseract based on a JAX function, use `tesseract init --rec
   - **How many times a call happens is not guaranteed.** Two identical calls in one
     traced function may be collapsed into one, and the compiler is in principle free to
     recompute a call to save memory. An endpoint that returns different results for
-    identical inputs — sampling without a seed input, reading mutable external state —
-    can therefore be called once where you expected twice, with both results being the
-    same value.
+    identical inputs, such as one sampling without a seed input or reading mutable
+    external state, can therefore be called once where you expected twice, with both
+    results being the same value.
 
   - **Ordering is not guaranteed** relative to other host callbacks such as
     `jax.debug.print`.

--- a/docs/content/get-started.md
+++ b/docs/content/get-started.md
@@ -97,3 +97,47 @@ When creating a new Tesseract based on a JAX function, use `tesseract init --rec
   ```{note}
   This only affects `from_tesseract_api` (in-process execution). Tesseracts served via Docker (`from_image`) run in a separate process and are not subject to this restriction.
   ```
+
+- **Tesseracts are assumed pure functions** of their inputs. Tesseract-JAX lowers each
+  endpoint call as a pure operation, which is what allows repeated identical calls to be
+  collapsed into a single request. Where purity does not hold, the compiler is free to
+  surprise you:
+  - **A call whose result is provably unused may not happen.**
+
+    ```python
+    @jax.jit
+    def unused_result(a):
+        _ = apply_tesseract(tess, inputs)["c"]   # not called: nothing depends on it
+        return a * 2.0
+
+    threshold_ok = False   # a concrete value, not a traced argument
+
+    @jax.jit
+    def dead_branch():
+        # the predicate is known at compile time, so the branch is dead
+        return jnp.where(threshold_ok, apply_tesseract(tess, inputs)["c"], 0.0)
+    ```
+
+    If the endpoint has an observable side effect — writing a file, logging to a
+    tracking server — that side effect will not happen either, and neither will any
+    error it would have raised. `abstract_eval` is still called while tracing, so a
+    Tesseract that fails abstract validation still fails.
+
+    This cuts both ways: guarding a call you know would be rejected is a legitimate way
+    to avoid it, as long as the guard is something the compiler can evaluate. A guard on
+    a traced value cannot be folded, so the call still happens.
+
+  - **How many times a call happens is not guaranteed.** Two identical calls in one
+    traced function may be collapsed into one, and the compiler is in principle free to
+    recompute a call to save memory. An endpoint that returns different results for
+    identical inputs — sampling without a seed input, reading mutable external state —
+    can therefore be called once where you expected twice, with both results being the
+    same value.
+
+  - **Ordering is not guaranteed** relative to other host callbacks such as
+    `jax.debug.print`.
+
+  If you have a Tesseract that genuinely depends on being called a particular number of
+  times, or in a particular order, please
+  [open an issue](https://github.com/pasteurlabs/tesseract-jax/issues) describing the
+  workflow.

--- a/tesseract_jax/primitive.py
+++ b/tesseract_jax/primitive.py
@@ -475,6 +475,16 @@ def tesseract_dispatch_lowering(
             out = (out,)
         return out
 
+    # A Tesseract endpoint is a pure function of its inputs, so declare it as one.
+    # This is what lets XLA's CSE fold repeated identical calls into a single
+    # request -- the same treatment a LAPACK custom call such as ``lu_factor``
+    # already gets. It relies on the bind params comparing equal for identical
+    # calls, which is why ``Jaxeract`` defines ``__eq__`` / ``__hash__``.
+    #
+    # Marking the callback side-effecting would *not* buy a guarantee that it
+    # always runs: JAX's own DCE already drops a Tesseract call whose outputs are
+    # unused, before XLA ever sees it. All it did was suppress CSE and pin the
+    # call's order against other effects.
     result, _, keepalive = mlir.emit_python_callback(
         ctx,
         _dispatch,
@@ -482,7 +492,7 @@ def tesseract_dispatch_lowering(
         array_args,
         ctx.avals_in,
         ctx.avals_out,
-        has_side_effect=True,
+        has_side_effect=False,
     )
     ctx.module_context.add_keepalive(keepalive)
     return result

--- a/tesseract_jax/tesseract_compat.py
+++ b/tesseract_jax/tesseract_compat.py
@@ -55,6 +55,24 @@ class Jaxeract:
 
         self.available_methods = self.client.available_endpoints
 
+    # Every attribute above is derived from ``self.client``, so two wrappers around
+    # the same Tesseract are interchangeable. Saying so matters: this object is a
+    # parameter of ``tesseract_dispatch_p``, and ``apply_tesseract`` builds a fresh
+    # one per call, so with the inherited identity semantics two otherwise identical
+    # calls lower to custom calls that XLA cannot recognise as equal and therefore
+    # cannot common up. Equality is delegated rather than based on the URL or schema
+    # so that distinct Tesseracts stay distinct; if ``Tesseract`` ever gains value
+    # semantics of its own, this inherits them.
+    def __eq__(self, other: object) -> bool:
+        """Whether ``other`` wraps the same Tesseract."""
+        if not isinstance(other, Jaxeract):
+            return NotImplemented
+        return self.client == other.client
+
+    def __hash__(self) -> int:
+        """Hash consistently with ``__eq__``."""
+        return hash((Jaxeract, self.client))
+
     # The abstract_eval method is never called from a dispatch function,
     # hence its signature does not need to be identical to the one of apply,
     # vjp and vjp.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,6 +233,11 @@ def mixed_dtype_tess() -> Tesseract:
     return _load_tesseract("mixed_dtype_tesseract")
 
 
+@pytest.fixture
+def validating_tess() -> Tesseract:
+    return _load_tesseract("validating_tesseract")
+
+
 # ---------------------------------------------------------------------------
 # Shared test inputs
 # ---------------------------------------------------------------------------

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -19,9 +19,10 @@ callback is lowered as side-effecting or pure.
 Exception *types* are normalised twice on the way out, so these tests pin what a
 caller actually sees rather than what the endpoint raised:
 
-* tesseract-core wraps whatever the endpoint raised in ``RuntimeError``
-* under ``jit``, anything raised inside the callback arrives as
-  ``jax.errors.JaxRuntimeError``
+* tesseract-core wraps anything raised *by the endpoint body* in ``RuntimeError``,
+  which covers cases 3 and 4 but not 2 -- input validation happens while parsing
+  the payload, before the body runs, so it surfaces as a ``ValidationError``
+* under ``jit``, all of them arrive as ``jax.errors.JaxRuntimeError``
 
 Case 1 escapes both, because it fails while tracing rather than in the callback.
 The *message* survives intact either way.
@@ -72,7 +73,12 @@ def test_abstract_validation_fails_before_dispatch(validating_tess, monkeypatch)
 
 @pytest.mark.parametrize("use_jit", [True, False])
 def test_value_based_input_validation_reaches_caller(validating_tess, use_jit):
-    """`x > 0` depends on the value, so it can only fail at run time."""
+    """`x > 0` depends on the value, so it can only fail at run time.
+
+    The bound is a schema-level ``AfterValidator``, so it fires while the payload is
+    being parsed rather than in the endpoint body -- which is why this is a
+    ``ValidationError`` and not wrapped in ``RuntimeError`` like cases 3 and 4.
+    """
 
     def f(x):
         return apply_tesseract(validating_tess, dict(x=x, v=V))["result"]
@@ -80,9 +86,8 @@ def test_value_based_input_validation_reaches_caller(validating_tess, use_jit):
     if use_jit:
         f = jax.jit(f)
 
-    with pytest.raises(
-        _expected_error(use_jit), match=r"x must be strictly positive, got -1\.0"
-    ):
+    expected = jax.errors.JaxRuntimeError if use_jit else ValidationError
+    with pytest.raises(expected, match=r"x must be strictly positive, got -1\.0"):
         jax.block_until_ready(f(jnp.array(-1.0, dtype="float64")))
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,193 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Failures must stay legible, including from inside a jitted callback.
+
+A Tesseract can fail in four distinguishable ways, and only the first is
+knowable at trace time:
+
+1. abstract (shape / dtype) validation -- caught before anything is dispatched
+2. value-based *input* validation      -- only knowable once values exist
+3. value-based *output* validation     -- the endpoint returned something invalid
+4. an exception raised inside the endpoint
+
+Cases 2-4 surface from inside the lowered callback, which is the interesting
+part: the original exception and message must still reach the caller rather than
+being swallowed or crashing the process. All four behave identically whether the
+callback is lowered as side-effecting or pure.
+
+Exception *types* are normalised twice on the way out, so these tests pin what a
+caller actually sees rather than what the endpoint raised:
+
+* tesseract-core wraps whatever the endpoint raised in ``RuntimeError``
+* under ``jit``, anything raised inside the callback arrives as
+  ``jax.errors.JaxRuntimeError``
+
+Case 1 escapes both, because it fails while tracing rather than in the callback.
+The *message* survives intact either way.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from tesseract_jax import apply_tesseract
+
+V = jnp.zeros(3, dtype="float64")
+
+
+def _expected_error(use_jit):
+    """What a caller sees when the endpoint raises."""
+    return jax.errors.JaxRuntimeError if use_jit else RuntimeError
+
+
+def _count_apply(tess, monkeypatch):
+    """Count apply endpoint invocations."""
+    calls = {"n": 0}
+    orig = tess.apply
+
+    def spy(*a, **kw):
+        calls["n"] += 1
+        return orig(*a, **kw)
+
+    monkeypatch.setattr(tess, "apply", spy)
+    return calls
+
+
+def test_abstract_validation_fails_before_dispatch(validating_tess, monkeypatch):
+    """A shape mismatch is caught at trace time and never reaches the endpoint."""
+    calls = _count_apply(validating_tess, monkeypatch)
+
+    @jax.jit
+    def f(v):
+        return apply_tesseract(validating_tess, dict(x=1.0, v=v))["result"]
+
+    with pytest.raises(ValidationError, match=r"Expected shape: \(3,\)"):
+        f(jnp.zeros(4, dtype="float64"))
+
+    assert calls["n"] == 0, "endpoint should never be reached"
+
+
+@pytest.mark.parametrize("use_jit", [True, False])
+def test_value_based_input_validation_reaches_caller(validating_tess, use_jit):
+    """`x > 0` depends on the value, so it can only fail at run time."""
+
+    def f(x):
+        return apply_tesseract(validating_tess, dict(x=x, v=V))["result"]
+
+    if use_jit:
+        f = jax.jit(f)
+
+    with pytest.raises(
+        _expected_error(use_jit), match=r"x must be strictly positive, got -1\.0"
+    ):
+        jax.block_until_ready(f(jnp.array(-1.0, dtype="float64")))
+
+
+@pytest.mark.parametrize("use_jit", [True, False])
+def test_value_based_output_validation_reaches_caller(validating_tess, use_jit):
+    """The endpoint returns valid Python that violates OutputSchema."""
+
+    def f(x):
+        return apply_tesseract(validating_tess, dict(x=x, v=V, mode="bad_output"))[
+            "result"
+        ]
+
+    if use_jit:
+        f = jax.jit(f)
+
+    with pytest.raises(
+        _expected_error(use_jit), match=r"(?s)OutputSchema.*non-numeric"
+    ):
+        jax.block_until_ready(f(jnp.array(4.0, dtype="float64")))
+
+
+@pytest.mark.parametrize("use_jit", [True, False])
+def test_exception_inside_endpoint_reaches_caller(validating_tess, use_jit):
+    """An exception raised in the endpoint body arrives with its message."""
+
+    def f(x):
+        return apply_tesseract(validating_tess, dict(x=x, v=V, mode="raise"))["result"]
+
+    if use_jit:
+        f = jax.jit(f)
+
+    with pytest.raises(
+        _expected_error(use_jit), match=r"deliberate failure inside the apply endpoint"
+    ):
+        jax.block_until_ready(f(jnp.array(4.0, dtype="float64")))
+
+
+def test_still_usable_after_a_failure(validating_tess):
+    """A failure is an ordinary Python exception and does not wedge the runtime.
+
+    Catching it needs nothing special: a plain ``try``/``except`` on
+    ``JaxRuntimeError`` works, the message is on the exception, and the very next
+    call succeeds.
+    """
+
+    @jax.jit
+    def f(x):
+        return apply_tesseract(validating_tess, dict(x=x, v=V))["result"]
+
+    bad = jnp.array(-1.0, dtype="float64")
+    good = jnp.array(4.0, dtype="float64")
+
+    # plain try/except, as a caller would write it
+    caught = None
+    try:
+        jax.block_until_ready(f(bad))
+    except jax.errors.JaxRuntimeError as exc:
+        caught = exc
+    assert caught is not None, "the failure must propagate to the caller"
+    assert "x must be strictly positive, got -1.0" in str(caught)
+
+    # ...and the runtime is unharmed
+    np.testing.assert_allclose(f(good), 2.0, rtol=1e-6)
+
+    # the same failure is equally catchable via pytest.raises, and recovering a
+    # second time still works
+    with pytest.raises(
+        jax.errors.JaxRuntimeError, match=r"x must be strictly positive"
+    ):
+        jax.block_until_ready(f(bad))
+    np.testing.assert_allclose(f(good), 2.0, rtol=1e-6)
+
+
+def test_guarded_call_is_elided_on_a_constant_predicate(validating_tess, monkeypatch):
+    """A guard XLA can fold spares the endpoint an invalid call.
+
+    Since the callback is lowered as pure, XLA may drop a branch whose predicate
+    it can evaluate at compile time -- so a caller who guards against invalid
+    input gets their guard honoured. With a traced predicate the guard cannot be
+    folded and the endpoint is still called, which is the pre-existing behaviour.
+    """
+    x = jnp.array(-1.0, dtype="float64")  # invalid for this Tesseract
+    calls = _count_apply(validating_tess, monkeypatch)
+
+    @jax.jit
+    def traced_predicate(x):
+        return jnp.where(
+            x > 0, apply_tesseract(validating_tess, dict(x=x, v=V))["result"], 0.0
+        )
+
+    with pytest.raises(
+        jax.errors.JaxRuntimeError, match=r"x must be strictly positive"
+    ):
+        jax.block_until_ready(traced_predicate(x))
+    assert calls["n"] == 1, "a traced guard cannot be folded, so the call happens"
+
+    calls["n"] = 0
+
+    @jax.jit
+    def constant_predicate():
+        # `x` is closed over as a concrete value, so `x > 0` is a compile-time
+        # constant and the branch is dead.
+        return jnp.where(
+            x > 0, apply_tesseract(validating_tess, dict(x=x, v=V))["result"], 0.0
+        )
+
+    np.testing.assert_allclose(constant_predicate(), 0.0, rtol=1e-6)
+    assert calls["n"] == 0, "a foldable guard should spare the endpoint entirely"

--- a/tests/test_jacobian_batching.py
+++ b/tests/test_jacobian_batching.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 from tesseract_jax import apply_tesseract
+from tesseract_jax.tesseract_compat import Jaxeract
 
 
 def _spy_endpoints(tess, monkeypatch):
@@ -429,3 +430,94 @@ def test_matches_jacrev_on_pure_jax(vectoradd_tess, use_jit, monkeypatch):
     M_tess = jax.jacfwd(f_tess)(a)
     M_jax = jax.jacfwd(f_jax)(a)
     np.testing.assert_allclose(M_tess, M_jax, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Common subexpression elimination of Tesseract calls
+#
+# A Tesseract endpoint is a pure function of its inputs, so XLA is free to fold
+# repeated identical calls into one request -- as it already does for LAPACK
+# custom calls. Two things are needed: the callback must be lowered as pure, and
+# the bind params (including the Jaxeract client) must compare equal.
+# ---------------------------------------------------------------------------
+
+
+def test_chunked_jacobian_calls_endpoint_once(vectoradd_tess, monkeypatch):
+    """Chunking the identity matrix must not multiply the ``jacobian`` requests.
+
+    Splitting the eye-vmap into chunks is a way to cap peak memory when the
+    Tesseract is one component of a larger function. The Jacobian does not depend
+    on the tangents, so every chunk issues an identical request and only one of
+    them needs to reach the Tesseract.
+    """
+    n = 6
+    a = jnp.arange(n, dtype="float32") + 1.0
+    b = jnp.full((n,), 0.5, dtype="float32")
+
+    def f(a):
+        # tanh stands in for the other, memory-hungry components that motivate
+        # chunking in the first place.
+        return jnp.tanh(apply_tesseract(vectoradd_tess, dict(a=a, b=b))["c"])
+
+    expected = jax.jacfwd(f)(a)
+    _primal, tangent_fn = jax.linearize(f, a)
+    batched = jax.vmap(tangent_fn)
+    eye = jnp.eye(n, dtype="float32")
+
+    # Spy only over the chunked computation, so the reference above is not counted.
+    counts = _spy_endpoints(vectoradd_tess, monkeypatch)
+    M = jax.jit(lambda e: jnp.concatenate([batched(c) for c in jnp.split(e, 3)]))(eye)
+
+    np.testing.assert_allclose(M, expected, atol=1e-6)
+    assert counts["jacobian"] == 1
+    assert counts["jvp"] == 0
+
+
+def test_identical_calls_are_commoned_up(vectoradd_tess, monkeypatch):
+    """Two identical ``apply_tesseract`` calls in one trace issue one request.
+
+    Both operands are passed as arguments rather than closed over: a concrete
+    closed-over array becomes a static arg wrapped in ``_Hashable``, which
+    compares by identity and so defeats CSE for unrelated reasons.
+    """
+    a = jnp.array([1.0, 2.0, 3.0], dtype="float32")
+    b = jnp.array([0.5, 0.5, 0.5], dtype="float32")
+
+    @jax.jit
+    def twice(a, b):
+        c1 = apply_tesseract(vectoradd_tess, dict(a=a, b=b))["c"]
+        c2 = apply_tesseract(vectoradd_tess, dict(a=a, b=b))["c"]
+        return c1 + c2
+
+    counts = _spy_endpoints(vectoradd_tess, monkeypatch)
+    out = twice(a, b)
+
+    np.testing.assert_allclose(out, 2.0 * (a + b), atol=1e-6)
+    assert counts["apply"] == 1
+
+
+def test_distinct_calls_are_not_commoned_up(vectoradd_tess, monkeypatch):
+    """Calls that differ in their inputs must stay separate requests."""
+    a1 = jnp.array([1.0, 2.0, 3.0], dtype="float32")
+    a2 = jnp.array([100.0, 200.0, 300.0], dtype="float32")
+    b = jnp.array([0.5, 0.5, 0.5], dtype="float32")
+
+    @jax.jit
+    def two_different(a1, a2, b):
+        c1 = apply_tesseract(vectoradd_tess, dict(a=a1, b=b))["c"]
+        c2 = apply_tesseract(vectoradd_tess, dict(a=a2, b=b))["c"]
+        return c1, c2
+
+    counts = _spy_endpoints(vectoradd_tess, monkeypatch)
+    c1, c2 = two_different(a1, a2, b)
+
+    np.testing.assert_allclose(c1, a1 + b, atol=1e-6)
+    np.testing.assert_allclose(c2, a2 + b, atol=1e-6)
+    assert counts["apply"] == 2
+
+
+def test_jaxeract_wrappers_compare_equal(vectoradd_tess):
+    """Distinct wrappers around one Tesseract are equal, so bind params match."""
+    assert Jaxeract(vectoradd_tess) == Jaxeract(vectoradd_tess)
+    assert hash(Jaxeract(vectoradd_tess)) == hash(Jaxeract(vectoradd_tess))
+    assert Jaxeract(vectoradd_tess) != object()

--- a/tests/validating_tesseract/tesseract_api.py
+++ b/tests/validating_tesseract/tesseract_api.py
@@ -7,22 +7,40 @@ Used to check that error reporting stays clean and attributable, in particular
 for failures that *cannot* surface at trace time because they depend on values
 rather than shapes.
 
-Note the positivity check on ``x`` lives in ``apply`` rather than as a pydantic
-``Field(gt=0)``: value constraints are also applied when ``abstract_eval``
-validates the schema against ``ShapeDType`` placeholders, where they raise
-``TypeError: '>' not supported between instances of 'ShapeDType' and 'float'``.
+The positivity bound on ``x`` is expressed as an ``AfterValidator`` that returns
+``ShapeDType`` untouched, rather than as ``Field(gt=0)``. A plain ``Field``
+constraint is also applied when ``abstract_eval`` validates the schema against
+``ShapeDType`` placeholders, where it dies with ``TypeError: '>' not supported
+between instances of 'ShapeDType' and 'float'``. Passing abstract values through
+is the workaround tesseract-core documents, and mirrors what ``ShapeDType``'s own
+shape validator does.
 """
 
+from typing import Annotated, Any
+
 import jax
-from pydantic import BaseModel, Field
+from pydantic import AfterValidator, BaseModel, Field
 from tesseract_core.runtime import Array, Differentiable, Float64, ShapeDType
 
 jax.config.update("jax_enable_x64", True)
 
 
+def _strictly_positive(value: Any) -> Any:
+    """Require a positive value, while leaving abstract evaluation alone.
+
+    ``abstract_eval`` validates this schema with ``ShapeDType`` placeholders in
+    place of values, so a value bound has to opt out of that pass explicitly.
+    """
+    if isinstance(value, ShapeDType):
+        return value
+    if value <= 0:
+        raise ValueError(f"x must be strictly positive, got {value}")
+    return value
+
+
 class InputSchema(BaseModel):
-    x: Differentiable[Float64] = Field(
-        description="Scalar x; apply requires it to be strictly positive."
+    x: Annotated[Differentiable[Float64], AfterValidator(_strictly_positive)] = Field(
+        description="Scalar x; must be strictly positive."
     )
     v: Array[(3,), Float64] = Field(
         default=(0.0, 0.0, 0.0), description="Fixed-shape vector of length 3."
@@ -44,11 +62,6 @@ def apply(inputs: InputSchema) -> OutputSchema:
     if inputs.mode == "bad_output":
         # Valid Python, but not a Float64 scalar -> OutputSchema rejects it.
         return OutputSchema(result="not a number")
-    if inputs.x <= 0:
-        raise ValueError(
-            f"x must be strictly positive, got {inputs.x}. "
-            f"This depends on the value, so it cannot be caught at trace time."
-        )
     return OutputSchema(result=inputs.x**0.5)
 
 

--- a/tests/validating_tesseract/tesseract_api.py
+++ b/tests/validating_tesseract/tesseract_api.py
@@ -1,0 +1,81 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A Tesseract whose failures span the ways one can go wrong.
+
+Used to check that error reporting stays clean and attributable, in particular
+for failures that *cannot* surface at trace time because they depend on values
+rather than shapes.
+
+Note the positivity check on ``x`` lives in ``apply`` rather than as a pydantic
+``Field(gt=0)``: value constraints are also applied when ``abstract_eval``
+validates the schema against ``ShapeDType`` placeholders, where they raise
+``TypeError: '>' not supported between instances of 'ShapeDType' and 'float'``.
+"""
+
+import jax
+from pydantic import BaseModel, Field
+from tesseract_core.runtime import Array, Differentiable, Float64, ShapeDType
+
+jax.config.update("jax_enable_x64", True)
+
+
+class InputSchema(BaseModel):
+    x: Differentiable[Float64] = Field(
+        description="Scalar x; apply requires it to be strictly positive."
+    )
+    v: Array[(3,), Float64] = Field(
+        default=(0.0, 0.0, 0.0), description="Fixed-shape vector of length 3."
+    )
+    mode: str = Field(
+        default="ok",
+        description="'ok', 'bad_output' (violate OutputSchema) or 'raise'.",
+    )
+
+
+class OutputSchema(BaseModel):
+    result: Differentiable[Float64] = Field(description="sqrt(x).")
+
+
+def apply(inputs: InputSchema) -> OutputSchema:
+    """Return sqrt(x), or misbehave on request."""
+    if inputs.mode == "raise":
+        raise RuntimeError("deliberate failure inside the apply endpoint")
+    if inputs.mode == "bad_output":
+        # Valid Python, but not a Float64 scalar -> OutputSchema rejects it.
+        return OutputSchema(result="not a number")
+    if inputs.x <= 0:
+        raise ValueError(
+            f"x must be strictly positive, got {inputs.x}. "
+            f"This depends on the value, so it cannot be caught at trace time."
+        )
+    return OutputSchema(result=inputs.x**0.5)
+
+
+def jacobian(inputs: InputSchema, jac_inputs: set[str], jac_outputs: set[str]):
+    return {"result": {"x": 0.5 * inputs.x**-0.5}}
+
+
+def jacobian_vector_product(
+    inputs: InputSchema,
+    jvp_inputs: set[str],
+    jvp_outputs: set[str],
+    tangent_vector,
+):
+    jac = jacobian(inputs, jvp_inputs, jvp_outputs)
+    return {"result": jac["result"]["x"] * tangent_vector["x"]}
+
+
+def vector_jacobian_product(
+    inputs: InputSchema,
+    vjp_inputs: set[str],
+    vjp_outputs: set[str],
+    cotangent_vector,
+):
+    jac = jacobian(inputs, vjp_inputs, vjp_outputs)
+    return {"x": jac["result"]["x"] * cotangent_vector["result"]}
+
+
+def abstract_eval(abstract_inputs):
+    """Shapes only -- value bounds are unknowable here, which is the point."""
+    return {"result": ShapeDType(shape=(), dtype="float64")}


### PR DESCRIPTION
#### Description of changes

* Sets `has_side_effect=False` unconditionally with no opt-out offered
* Add `__eq__` and `__hash__` methods on to `Jaxeract` to establish equality based on Tesseract equality (at the moment this is just identity; we could expand tesseract-core to include identity based on url but I don't think its really necessary).

The current approach of setting `has_side_effect=True` prevents XLA from being overly aggressive with CSE but does not guarantee every coded up call will result in an endpoint request (for example, DCE is still possible if no output is used at all). Given `has_side_effect=True` doesn't really do what it says on the tin (we have to look at post-DCE jaxpr to estimate the number of actual requests) and the kind of side effects that Tesseracts are expected to have (e.g. mlflow logging or other diagnostic information) should not cause issues if an endpoint call is missed I'm proposing to set `has_side_effect=False` for the reasons listed below. Behaviour will change if a Tesseract is not a pure function (i.e. there is a counter that returns a traced array based on how many times an endpoint has been called) but using JAX in such a situation would never have been safe anyway.

One particular use case is [chunking a jacobian](https://github.com/unalmis/adv-jax-math) to cap peak memory when a Tesseract is one component of a larger function: split the identity matrix, run the linearized function over each chunk, concatenate. If the Tesseract has `materialize_jacobian=True` this will result in multiple `jacobian` requests, but the Jacobian does not depend on the tangents, so every chunk issues a byte-for-byte identical output if CSE is disabled.

Note the **eager** path does not go through lowering, so an un-jitted chunk loop still issues one request per chunk.

#### Exceptions, and what https://github.com/pasteurlabs/tesseract-jax/pull/44 was protecting 

PR https://github.com/pasteurlabs/tesseract-jax/pull/44 set `has_side_effect=True` deliberately, because our callbacks can raise and the JAX docs warn that exceptions from a pure callback leave the program's behaviour undefined. Measuring this:

                                  =True              =False
    output used                   JaxRuntimeError    JaxRuntimeError
    two identical calls (CSE)     JaxRuntimeError    JaxRuntimeError
    output discarded              no error, 0 calls  no error, 0 calls
    consumer folded away in HLO   JaxRuntimeError    no error, 0 calls

CSE itself is error-safe. Folding two identical calls into one still raises, with the same exception, so the optimization this commit enables does not lose failures. https://github.com/pasteurlabs/tesseract-jax/pull/44's concern does not bear on it.

Importantly, a call whose output goes unused already issues no request and reports no error even under `has_side_effect=True`, because JAX's own DCE removes the eqn before lowering, which is where the flag lives.

One case does regress: when the output is consumed at the jaxpr level but XLA can fold the consumer away -- `jnp.where(jnp.array(False), c, a)` -- `True` keeps the call and surfaces the error where `False` elides both. Read against the row above, that makes `True` incoherent rather than protective: eliding via DCE loses the error, eliding via constant folding keeps it, and which you get depends on whichever layer happens to notice the result is dead. `False` is at least consistent -- if nobody needs the result, the Tesseract is not called and its errors are not reported.

#### Testing done

Added explicit tests to ensure expected behaviour through CI. Checked for absence of over-eager folding: calls that differ in their inputs still issue separate requests.

