### PR TITLE
fix: keep dotted dict keys whole when matching schema templates

### DIFF
--- a/tesseract_jax/tree_util.py
+++ b/tesseract_jax/tree_util.py
@@ -72,20 +72,53 @@ def unflatten_args(
     return result
 
 
+def _split_path(path: str) -> list[str]:
+    """Split a path on the dots that separate segments.
+
+    A dot inside ``{...}`` belongs to the key, so ``a.{b.c}`` is two segments
+    rather than three.
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    for char in path:
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        if char == "." and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(char)
+    parts.append("".join(buf))
+    return parts
+
+
 def _merge_path(
-    explicit_path: str, array_paths: Iterable[str]
+    explicit_path: str | Sequence[str], array_paths: Iterable[str]
 ) -> tuple[str, str | None]:
     """Merges and formats explicit path with array paths containing templates.
 
     Returns a tuple of (formatted_path, matched_template) where matched_template
     is the template string that matched, or None if no template matched.
 
+    ``explicit_path`` may be given as the already-joined string or as the
+    segments it was built from. A dict key is free to contain dots, so passing
+    the segments is the only way to say where one ends; joining first and
+    splitting again cannot tell ``{"a": {"b.c": v}}`` from ``{"a": {"b": {"c": v}}}``.
+
     Examples:
         _merge_path('alpha.beta.x', ['alpha.beta.{}']) -> ('alpha.beta.{x}', 'alpha.beta.{}')
         _merge_path('delta.[2]', ['delta.[]']) -> ('delta.[2]', 'delta.[]')
         _merge_path('epsilon.k', ['alpha.{}']) -> ('epsilon.k', None)
+        _merge_path(['params', 'a.b'], ['params.{}']) -> ('params.{a.b}', 'params.{}')
     """
-    explicit_parts = explicit_path.split(".")
+    if isinstance(explicit_path, str):
+        explicit_parts = _split_path(explicit_path)
+    else:
+        explicit_parts = list(explicit_path)
+
     for array_path in array_paths:
         template_parts = array_path.split(".")
         if len(template_parts) != len(explicit_parts):
@@ -97,7 +130,9 @@ def _merge_path(
             if tp == ep:
                 result_parts.append(ep)
             elif tp == "{}":
-                result_parts.append(f"{{{ep}}}")
+                # Idempotent: batching re-merges paths this function produced.
+                already = ep.startswith("{") and ep.endswith("}")
+                result_parts.append(ep if already else f"{{{ep}}}")
             elif tp == "[]":
                 result_parts.append(ep)  # already "[n]"
             else:
@@ -107,7 +142,7 @@ def _merge_path(
         if matched:
             return ".".join(result_parts), array_path
 
-    return explicit_path, None
+    return ".".join(explicit_parts), None
 
 
 def _pytree_to_tesseract_flat(
@@ -134,20 +169,18 @@ def _pytree_to_tesseract_flat(
 
     flat_dict = {}
     for jax_path, val in leaves:
-        tesseract_path = ""
+        # Keep the segments rather than joining them: a dict key may itself
+        # contain a dot, and joining first loses where the key ends.
+        path_parts: list[str] = []
         for elem in jax_path:
             # for handling dicts
             if hasattr(elem, "key"):
-                tesseract_path += f".{elem.key}"
+                path_parts.append(str(elem.key))
             # for handling lists/tuples
             elif hasattr(elem, "idx"):
-                tesseract_path += f".[{elem.idx}]"
-        # remove leading dot
-        tesseract_path = tesseract_path.lstrip(".")
+                path_parts.append(f"[{elem.idx}]")
 
-        tesseract_path, matched_template = _merge_path(
-            tesseract_path, schema_paths or []
-        )
+        tesseract_path, matched_template = _merge_path(path_parts, schema_paths or [])
 
         flat_dict[tesseract_path] = val if matched_template else None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,6 +214,11 @@ def pytree_tess() -> Tesseract:
 
 
 @pytest.fixture
+def dict_key_tess() -> Tesseract:
+    return _load_tesseract("dict_key_tesseract")
+
+
+@pytest.fixture
 def univariate_tess() -> Tesseract:
     return _load_tesseract("univariate_tesseract")
 

--- a/tests/dict_key_tesseract/tesseract_api.py
+++ b/tests/dict_key_tesseract/tesseract_api.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dict-valued differentiable field whose keys are not plain words.
+
+A state dict is the obvious thing to put in one, and its keys carry dots.
+"""
+
+from typing import Any
+
+import numpy as np
+from pydantic import BaseModel
+from tesseract_core.runtime import Array, Differentiable, Float32
+
+
+class InputSchema(BaseModel):
+    params: dict[str, Differentiable[Array[(3,), Float32]]]
+
+
+class OutputSchema(BaseModel):
+    result: Differentiable[Array[(3,), Float32]]
+
+
+def apply(inputs: InputSchema) -> OutputSchema:
+    p = inputs.model_dump()["params"]
+    return {"result": sum(2.0 * np.asarray(v, np.float32) for v in p.values())}
+
+
+def vector_jacobian_product(
+    inputs: InputSchema,
+    vjp_inputs: set[str],
+    vjp_outputs: set[str],
+    cotangent_vector: dict[str, Any],
+) -> dict[str, Any]:
+    ct = np.asarray(cotangent_vector["result"], np.float32)
+    return {k: 2.0 * ct for k in vjp_inputs}
+
+
+def abstract_eval(abstract_inputs: Any) -> dict:
+    return {"result": {"shape": (3,), "dtype": "float32"}}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+import tesseract_core
+from packaging.version import Version
 
 from tesseract_jax import apply_tesseract
 
@@ -778,12 +780,9 @@ def test_merge_path_keeps_dotted_dict_keys_whole(explicit, templates, expected):
     assert template == templates[0]
 
 
-try:  # tesseract-core widened its dict-key pattern in pasteurlabs/tesseract-core#707
-    from tesseract_core.runtime.tree_transforms import split_path  # noqa: F401
-
-    _CORE_ACCEPTS_WIDE_KEYS = True
-except ImportError:  # pragma: no cover
-    _CORE_ACCEPTS_WIDE_KEYS = False
+# tesseract-core widened its dict-key pattern in pasteurlabs/tesseract-core#707,
+# which landed after 1.12.0. Drop this guard once the minimum version is past it.
+_CORE_ACCEPTS_WIDE_KEYS = Version(tesseract_core.__version__) > Version("1.12.0")
 
 
 @pytest.mark.parametrize(
@@ -794,7 +793,10 @@ except ImportError:  # pragma: no cover
             "layer.0.weight",
             marks=pytest.mark.skipif(
                 not _CORE_ACCEPTS_WIDE_KEYS,
-                reason="runtime rejects the key until tesseract-core#707 is released",
+                reason=(
+                    f"tesseract-core {tesseract_core.__version__} rejects the key "
+                    "(needs > 1.12.0)"
+                ),
             ),
         ),
     ],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -776,3 +776,33 @@ def test_merge_path_keeps_dotted_dict_keys_whole(explicit, templates, expected):
     path, template = _merge_path(explicit, templates)
     assert path == expected
     assert template == templates[0]
+
+
+try:  # tesseract-core widened its dict-key pattern in pasteurlabs/tesseract-core#707
+    from tesseract_core.runtime.tree_transforms import split_path  # noqa: F401
+
+    _CORE_ACCEPTS_WIDE_KEYS = True
+except ImportError:  # pragma: no cover
+    _CORE_ACCEPTS_WIDE_KEYS = False
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "plain",
+        pytest.param(
+            "layer.0.weight",
+            marks=pytest.mark.skipif(
+                not _CORE_ACCEPTS_WIDE_KEYS,
+                reason="runtime rejects the key until tesseract-core#707 is released",
+            ),
+        ),
+    ],
+)
+def test_grad_reaches_a_dotted_dict_key(dict_key_tess, key):
+    """End to end: a state-dict key carries dots and still gets its gradient."""
+    inputs = {"params": {key: jnp.ones(3, dtype=jnp.float32)}}
+    grads = jax.grad(lambda x: apply_tesseract(dict_key_tess, x)["result"].sum())(
+        inputs
+    )
+    np.testing.assert_allclose(np.asarray(grads["params"][key]), np.full(3, 2.0))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -751,3 +751,28 @@ def test_pytree_tesseract_jvp_preserves_list_order(
 
     _, expected = jax.jvp(f_raw, (d1,), (tangent,))
     np.testing.assert_allclose(jvp(d1, tangent), expected, rtol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "explicit,templates,expected",
+    [
+        (["params", "plain"], ["params.{}"], "params.{plain}"),
+        (["params", "a/b"], ["params.{}"], "params.{a/b}"),
+        (["params", "layer.0.weight"], ["params.{}"], "params.{layer.0.weight}"),
+        # Re-merging a path this function produced must not brace it twice,
+        # which batching relies on.
+        ("params.{layer.0.weight}", ["params.{}"], "params.{layer.0.weight}"),
+    ],
+)
+def test_merge_path_keeps_dotted_dict_keys_whole(explicit, templates, expected):
+    """A dict key may contain dots, and the key is where the path ends.
+
+    Joining the segments first and splitting again cannot tell
+    {"a": {"b.c": v}} from {"a": {"b": {"c": v}}}, so a dotted key used to
+    miss its template and be reported as a non-differentiable input.
+    """
+    from tesseract_jax.tree_util import _merge_path
+
+    path, template = _merge_path(explicit, templates)
+    assert path == expected
+    assert template == templates[0]


### PR DESCRIPTION
A dict key may contain dots, so joining the pytree segments into a path and splitting it again cannot tell `{"a": {"b.c": v}}` from `{"a": {"b": {"c": v}}}`. That is why a dotted key missed its template and came back as a non-differentiable input.

`_pytree_to_tesseract_flat` now passes `_merge_path` the segments it already had rather than a joined string. `_merge_path` still takes a string, splitting on the dots outside braces, and no longer braces a segment that is already braced, which is what `batching` needs when it re-merges a path this function produced.

```
jax.grad through params.{layer.0.weight}
  before  ValueError: Non-symbolic-zero tangent provided for non-differentiable input
  after   grad=[2. 2. 2.]
```

Needs the pattern from pasteurlabs/tesseract-core#707 to reach the runtime, so I verified against tesseract-core `main` rather than the released 1.12.0. 283 passed.

Fixes #251.
