### PR TITLE
refactor: bundle primitive dispatch kwargs into a DispatchParams dataclass

### DIFF
--- a/tesseract_jax/batching.py
+++ b/tesseract_jax/batching.py
@@ -7,20 +7,21 @@ See :doc:`/content/vmap-methods` for a guide on choosing the right method.
 """
 
 from itertools import compress
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import jax
 import jax.numpy as jnp
 from jax import ShapeDtypeStruct
-from jax.tree_util import PyTreeDef
 
-from tesseract_jax.tesseract_compat import Jaxeract
 from tesseract_jax.tree_util import (
     _merge_path,
     _pytree_to_tesseract_flat,
     combine_args,
     split_args,
 )
+
+if TYPE_CHECKING:
+    from tesseract_jax.dispatch_params import DispatchParams
 
 VmapMethod = (
     Literal["sequential", "auto_experimental", "expand_dims", "broadcast_all"] | None
@@ -47,24 +48,12 @@ def _dispatch_vectorized(
     batch_size: int,
     n_primals: int,
     *,
-    static_args: tuple,
-    input_pytreedef: PyTreeDef,
-    output_pytreedef: PyTreeDef,
-    output_avals: tuple[ShapeDtypeStruct, ...],
-    is_static_mask: tuple[bool, ...],
-    has_tangent: tuple[bool, ...],
-    client: Jaxeract,
-    eval_func: str,
-    vmap_method: "VmapMethod",
+    params: "DispatchParams",
     tesseract_dispatch_p: Any,
-    materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
-    jac_mode: str = "bwd",
 ) -> tuple[tuple, tuple]:
     """Common vectorized dispatch: broadcast JVP tangents, prepend batch dim, bind."""
     # JVP: broadcast primal/tangent to match if batch dims differ
-    if eval_func == "jacobian_vector_product":
+    if params.eval_func == "jacobian_vector_product":
         for i in range(n_primals):
             if is_batched_mask[i] != is_batched_mask[i + n_primals]:
                 new_args[i], new_args[i + n_primals] = jnp.broadcast_arrays(
@@ -73,23 +62,11 @@ def _dispatch_vectorized(
 
     batched_output_avals = tuple(
         ShapeDtypeStruct(shape=(batch_size, *aval.shape), dtype=aval.dtype)
-        for aval in output_avals
+        for aval in params.output_avals
     )
     outvals = tesseract_dispatch_p.bind(
         *new_args,
-        static_args=static_args,
-        input_pytreedef=input_pytreedef,
-        output_pytreedef=output_pytreedef,
-        output_avals=batched_output_avals,
-        is_static_mask=is_static_mask,
-        has_tangent=has_tangent,
-        client=client,
-        eval_func=eval_func,
-        vmap_method=vmap_method,
-        materialize_jacobian=materialize_jacobian,
-        jac_input_paths=jac_input_paths,
-        jac_output_paths=jac_output_paths,
-        jac_mode=jac_mode,
+        params=params.replace(output_avals=batched_output_avals),
     )
     return tuple(outvals), (0,) * len(outvals)
 
@@ -103,42 +80,15 @@ def sequential(
     new_args: list,
     is_batched_mask: list[bool],
     *,
-    static_args: tuple,
-    input_pytreedef: PyTreeDef,
-    output_pytreedef: PyTreeDef,
-    output_avals: tuple[ShapeDtypeStruct, ...],
-    is_static_mask: tuple[bool, ...],
-    has_tangent: tuple[bool, ...],
-    client: Jaxeract,
-    eval_func: str,
-    vmap_method: "VmapMethod",
+    params: "DispatchParams",
     tesseract_dispatch_p: Any,
-    materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
-    jac_mode: str = "bwd",
 ) -> tuple[tuple, tuple]:
     """One Tesseract call per batch element via ``jax.lax.map``."""
     unbatched_args, batched_args = split_args(new_args, is_batched_mask)
 
     def _batch_fun(batched_args: tuple):
         combined_args = combine_args(unbatched_args, batched_args, is_batched_mask)
-        return tesseract_dispatch_p.bind(
-            *combined_args,
-            static_args=static_args,
-            input_pytreedef=input_pytreedef,
-            output_pytreedef=output_pytreedef,
-            output_avals=output_avals,
-            is_static_mask=is_static_mask,
-            has_tangent=has_tangent,
-            client=client,
-            eval_func=eval_func,
-            vmap_method=vmap_method,
-            materialize_jacobian=materialize_jacobian,
-            jac_input_paths=jac_input_paths,
-            jac_output_paths=jac_output_paths,
-            jac_mode=jac_mode,
-        )
+        return tesseract_dispatch_p.bind(*combined_args, params=params)
 
     outvals = jax.lax.map(_batch_fun, batched_args)
     return tuple(outvals), (0,) * len(outvals)
@@ -148,47 +98,22 @@ def expand_dims(
     new_args: list,
     is_batched_mask: list[bool],
     *,
-    static_args: tuple,
-    input_pytreedef: PyTreeDef,
-    output_pytreedef: PyTreeDef,
-    output_avals: tuple[ShapeDtypeStruct, ...],
-    is_static_mask: tuple[bool, ...],
-    has_tangent: tuple[bool, ...],
-    client: Jaxeract,
-    eval_func: str,
-    vmap_method: "VmapMethod",
+    params: "DispatchParams",
     tesseract_dispatch_p: Any,
-    materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
-    jac_mode: str = "bwd",
 ) -> tuple[tuple, tuple]:
     """Add a leading ``(1,)`` dim to unbatched array args; single Tesseract call.
 
     The Tesseract is responsible for broadcasting ``(1, ...)`` against
     ``(batch, ...)`` internally (e.g. via NumPy broadcasting rules).
     """
-    kwargs = dict(
-        static_args=static_args,
-        input_pytreedef=input_pytreedef,
-        output_pytreedef=output_pytreedef,
-        output_avals=output_avals,
-        is_static_mask=is_static_mask,
-        has_tangent=has_tangent,
-        client=client,
-        eval_func=eval_func,
-        vmap_method=vmap_method,
-        tesseract_dispatch_p=tesseract_dispatch_p,
-        materialize_jacobian=materialize_jacobian,
-        jac_input_paths=jac_input_paths,
-        jac_output_paths=jac_output_paths,
-        jac_mode=jac_mode,
-    )
-    n_primals = len(is_static_mask) - sum(is_static_mask)
+    kwargs = dict(params=params, tesseract_dispatch_p=tesseract_dispatch_p)
+    n_primals = params.n_primals
     batch_size = _get_batch_size(new_args, is_batched_mask)
 
     # Tesseracts don't support batched cotangents
-    if eval_func == "vector_jacobian_product" and any(is_batched_mask[n_primals:]):
+    if params.eval_func == "vector_jacobian_product" and any(
+        is_batched_mask[n_primals:]
+    ):
         return sequential(new_args, is_batched_mask, **kwargs)
 
     new_args = [
@@ -205,20 +130,8 @@ def broadcast_all(
     new_args: list,
     is_batched_mask: list[bool],
     *,
-    static_args: tuple,
-    input_pytreedef: PyTreeDef,
-    output_pytreedef: PyTreeDef,
-    output_avals: tuple[ShapeDtypeStruct, ...],
-    is_static_mask: tuple[bool, ...],
-    has_tangent: tuple[bool, ...],
-    client: Jaxeract,
-    eval_func: str,
-    vmap_method: "VmapMethod",
+    params: "DispatchParams",
     tesseract_dispatch_p: Any,
-    materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
-    jac_mode: str = "bwd",
 ) -> tuple[tuple, tuple]:
     """Broadcast unbatched array args to ``(batch, ...)``; single Tesseract call.
 
@@ -226,27 +139,14 @@ def broadcast_all(
     dimension. This is useful for Tesseracts that require all inputs to have
     matching shapes.
     """
-    kwargs = dict(
-        static_args=static_args,
-        input_pytreedef=input_pytreedef,
-        output_pytreedef=output_pytreedef,
-        output_avals=output_avals,
-        is_static_mask=is_static_mask,
-        has_tangent=has_tangent,
-        client=client,
-        eval_func=eval_func,
-        vmap_method=vmap_method,
-        tesseract_dispatch_p=tesseract_dispatch_p,
-        materialize_jacobian=materialize_jacobian,
-        jac_input_paths=jac_input_paths,
-        jac_output_paths=jac_output_paths,
-        jac_mode=jac_mode,
-    )
-    n_primals = len(is_static_mask) - sum(is_static_mask)
+    kwargs = dict(params=params, tesseract_dispatch_p=tesseract_dispatch_p)
+    n_primals = params.n_primals
     batch_size = _get_batch_size(new_args, is_batched_mask)
 
     # Tesseracts don't support batched cotangents
-    if eval_func == "vector_jacobian_product" and any(is_batched_mask[n_primals:]):
+    if params.eval_func == "vector_jacobian_product" and any(
+        is_batched_mask[n_primals:]
+    ):
         return sequential(new_args, is_batched_mask, **kwargs)
 
     new_args = [
@@ -263,20 +163,8 @@ def auto_experimental(
     new_args: list,
     is_batched_mask: list[bool],
     *,
-    static_args: tuple,
-    input_pytreedef: PyTreeDef,
-    output_pytreedef: PyTreeDef,
-    output_avals: tuple[ShapeDtypeStruct, ...],
-    is_static_mask: tuple[bool, ...],
-    has_tangent: tuple[bool, ...],
-    client: Jaxeract,
-    eval_func: str,
-    vmap_method: "VmapMethod",
+    params: "DispatchParams",
     tesseract_dispatch_p: Any,
-    materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
-    jac_mode: str = "bwd",
 ) -> tuple[tuple, tuple]:
     """Auto-detect whether to vectorize based on the schema.
 
@@ -285,31 +173,18 @@ def auto_experimental(
     dimension to unbatched args and sends a single batched Tesseract call.
     Otherwise falls back to sequential.
     """
-    kwargs = dict(
-        static_args=static_args,
-        input_pytreedef=input_pytreedef,
-        output_pytreedef=output_pytreedef,
-        output_avals=output_avals,
-        is_static_mask=is_static_mask,
-        has_tangent=has_tangent,
-        client=client,
-        eval_func=eval_func,
-        vmap_method=vmap_method,
-        tesseract_dispatch_p=tesseract_dispatch_p,
-        materialize_jacobian=materialize_jacobian,
-        jac_input_paths=jac_input_paths,
-        jac_output_paths=jac_output_paths,
-        jac_mode=jac_mode,
-    )
-    n_primals = len(is_static_mask) - sum(is_static_mask)
+    kwargs = dict(params=params, tesseract_dispatch_p=tesseract_dispatch_p)
+    n_primals = params.n_primals
     batch_size = _get_batch_size(new_args, is_batched_mask)
 
     # Tesseracts don't support batched cotangents
-    if eval_func == "vector_jacobian_product" and any(is_batched_mask[n_primals:]):
+    if params.eval_func == "vector_jacobian_product" and any(
+        is_batched_mask[n_primals:]
+    ):
         return sequential(new_args, is_batched_mask, **kwargs)
 
     # Determine which primal args need to support a batch dimension
-    if eval_func == "jacobian_vector_product":
+    if params.eval_func == "jacobian_vector_product":
         needs_ellipsis = [
             b_p or b_t
             for b_p, b_t in zip(
@@ -321,10 +196,12 @@ def auto_experimental(
 
     # Match each primal arg to its differentiable schema template.
     # A field has "ellipsis" shape if its template has no "shape" key.
-    diff_paths = client.differentiable_input_paths
-    dummy_tree = jax.tree.unflatten(input_pytreedef, range(len(is_static_mask)))
+    diff_paths = params.client.differentiable_input_paths
+    dummy_tree = jax.tree.unflatten(
+        params.input_pytreedef, range(len(params.is_static_mask))
+    )
     flat_info = _pytree_to_tesseract_flat(dummy_tree, schema_paths=diff_paths)
-    primal_info = compress(flat_info.items(), (not s for s in is_static_mask))
+    primal_info = compress(flat_info.items(), (not s for s in params.is_static_mask))
     primal_templates = [
         _merge_path(path, diff_paths)[1] if val is not None else None
         for path, val in primal_info

--- a/tesseract_jax/dispatch_params.py
+++ b/tesseract_jax/dispatch_params.py
@@ -1,0 +1,74 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The parameter bundle threaded through the ``tesseract_dispatch`` primitive.
+
+Every rule of the primitive (abstract eval, jvp, transpose, batching, lowering,
+impl) and every batching strategy needs the same set of descriptors: how the
+flat operands map back to the input pytree, what the outputs look like, which
+endpoint to call, and how to handle vmap. Passing them as a dozen individual
+keyword arguments made the signatures unwieldy, so they live together in a
+single frozen dataclass that travels as one primitive bind parameter.
+
+The dataclass is frozen and every field is hashable, which is what lets JAX
+compare two binds for equality and lets XLA common up identical Tesseract
+calls (see the CSE note in ``primitive.py``).
+"""
+
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any, Literal
+
+from jax import ShapeDtypeStruct
+from jax.tree_util import PyTreeDef
+
+if TYPE_CHECKING:
+    from tesseract_jax.batching import VmapMethod
+    from tesseract_jax.tesseract_compat import Jaxeract
+
+
+@dataclass(frozen=True)
+class DispatchParams:
+    """Descriptors carried by the ``tesseract_dispatch`` primitive.
+
+    Attributes:
+        static_args: Non-traced leaves of the input pytree, wrapped so they hash.
+        input_pytreedef: Treedef to reassemble the flat operands into inputs.
+        output_pytreedef: Treedef for the outputs; ``None`` when the Tesseract
+            has no ``abstract_eval`` endpoint and outputs stay unflattened.
+        output_avals: Shape/dtype of each flat output; ``None`` alongside
+            ``output_pytreedef``.
+        is_static_mask: One flag per input leaf, ``True`` where the leaf is static.
+        has_tangent: One flag per non-static input, ``True`` where a (co)tangent
+            is carried for it.
+        client: The Tesseract wrapper the call dispatches to.
+        eval_func: Which endpoint to invoke (``apply``, ``jacobian_vector_product``,
+            ``vector_jacobian_product`` or ``jacobian``).
+        vmap_method: Strategy for ``jax.vmap`` batching; see ``batching.py``.
+        materialize_jacobian: Strategy for batching (co)tangents at a single primal.
+        jac_input_paths: When set, restrict a ``jacobian`` call to these input columns.
+        jac_output_paths: When set, restrict a ``jacobian`` call to these output rows.
+        jac_mode: Dtype convention for a ``jacobian`` call (``"bwd"`` / ``"fwd"``).
+    """
+
+    static_args: tuple[Any, ...]
+    input_pytreedef: PyTreeDef
+    output_pytreedef: PyTreeDef | None
+    output_avals: tuple[ShapeDtypeStruct, ...] | None
+    is_static_mask: tuple[bool, ...]
+    has_tangent: tuple[bool, ...]
+    client: "Jaxeract"
+    eval_func: str
+    vmap_method: "VmapMethod" = None
+    materialize_jacobian: bool | None = None
+    jac_input_paths: tuple[str, ...] | None = None
+    jac_output_paths: tuple[str, ...] | None = None
+    jac_mode: Literal["fwd", "bwd"] = "bwd"
+
+    @property
+    def n_primals(self) -> int:
+        """Number of non-static input leaves."""
+        return len(self.is_static_mask) - sum(self.is_static_mask)
+
+    def replace(self, **changes: Any) -> "DispatchParams":
+        """Return a copy with the given fields overridden."""
+        return replace(self, **changes)

--- a/tesseract_jax/dispatch_params.py
+++ b/tesseract_jax/dispatch_params.py
@@ -3,7 +3,7 @@
 
 """The parameter bundle threaded through the ``tesseract_dispatch`` primitive.
 
-Every rule of the primitive and every batching strategy needs the same 
+Every rule of the primitive and every batching strategy needs the same
 set of descriptors. Passing them as a single frozen dataclass is neater than
 a dozen individual keyword arguments on every rule signatures.
 

--- a/tesseract_jax/dispatch_params.py
+++ b/tesseract_jax/dispatch_params.py
@@ -3,12 +3,9 @@
 
 """The parameter bundle threaded through the ``tesseract_dispatch`` primitive.
 
-Every rule of the primitive (abstract eval, jvp, transpose, batching, lowering,
-impl) and every batching strategy needs the same set of descriptors: how the
-flat operands map back to the input pytree, what the outputs look like, which
-endpoint to call, and how to handle vmap. Passing them as a dozen individual
-keyword arguments made the signatures unwieldy, so they live together in a
-single frozen dataclass that travels as one primitive bind parameter.
+Every rule of the primitive and every batching strategy needs the same 
+set of descriptors. Passing them as a single frozen dataclass is neater than
+a dozen individual keyword arguments on every rule signatures.
 
 The dataclass is frozen and every field is hashable, which is what lets JAX
 compare two binds for equality and lets XLA common up identical Tesseract

--- a/tesseract_jax/primitive.py
+++ b/tesseract_jax/primitive.py
@@ -3,21 +3,21 @@
 
 import operator
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import Any
 
 import jax
 import jax.core as jc
 import jax.numpy as jnp
 import jax.tree
 import numpy as np
-from jax import ShapeDtypeStruct, dtypes, extend
+from jax import dtypes, extend
 from jax.core import ShapedArray
 from jax.interpreters import ad, batching, mlir
-from jax.tree_util import PyTreeDef
 from jax.typing import ArrayLike
 from tesseract_core import Tesseract
 
 from tesseract_jax.batching import VMAP_METHOD_DISPATCH, VmapMethod
+from tesseract_jax.dispatch_params import DispatchParams
 from tesseract_jax.tesseract_compat import Jaxeract
 from tesseract_jax.tree_util import (
     _pytree_to_tesseract_flat,
@@ -57,46 +57,37 @@ def _instantiate_zeros(tangents: Sequence[Any]) -> tuple[ArrayLike, ...]:
 @tesseract_dispatch_p.def_abstract_eval
 def tesseract_dispatch_abstract_eval(
     *array_args: ArrayLike | ShapedArray,
-    static_args: tuple[_Hashable, ...],
-    input_pytreedef: PyTreeDef,
-    output_pytreedef: PyTreeDef,
-    output_avals: tuple[ShapeDtypeStruct, ...],
-    is_static_mask: tuple[bool, ...],
-    has_tangent: tuple[bool, ...],
-    client: Jaxeract,
-    eval_func: str,
-    vmap_method: VmapMethod = None,
-    materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
-    jac_mode: Literal["fwd", "bwd"] = "bwd",
+    params: DispatchParams,
 ) -> tuple:
     """Define how to dispatch evals and pipe arguments."""
-    if eval_func not in (
+    if params.eval_func not in (
         "apply",
         "jacobian_vector_product",
         "vector_jacobian_product",
         "jacobian",
     ):
-        raise NotImplementedError(eval_func)
+        raise NotImplementedError(params.eval_func)
 
-    n_primals = len(is_static_mask) - sum(is_static_mask)
+    n_primals = params.n_primals
 
-    if eval_func == "vector_jacobian_product":
+    if params.eval_func == "vector_jacobian_product":
         # We mustn't run forward evaluation of shapes, as out
         # of vjp has the same shapes as the primals; thus we can return early
         return tuple(array_args[:n_primals])
 
-    if eval_func == "jacobian":
+    if params.eval_func == "jacobian":
         # One array per (diff_output, diff_input) pair, shape = out_shape + in_shape.
         # `jac_input_paths` / `jac_output_paths` (when provided) restrict the
         # request to a sub-block of the Jacobian.
         primal_avals = array_args[:n_primals]
         primal_inputs = unflatten_args(
-            primal_avals, static_args, input_pytreedef, is_static_mask
+            primal_avals,
+            params.static_args,
+            params.input_pytreedef,
+            params.is_static_mask,
         )
         flat_inputs = _pytree_to_tesseract_flat(
-            primal_inputs, schema_paths=client.differentiable_input_paths
+            primal_inputs, schema_paths=params.client.differentiable_input_paths
         )
         path_to_shape = {
             p: (tuple(v.shape), v.dtype)
@@ -104,22 +95,26 @@ def tesseract_dispatch_abstract_eval(
             if v is not None
         }
         output_flat = _pytree_to_tesseract_flat(
-            jax.tree.unflatten(output_pytreedef, range(len(output_avals))),
-            schema_paths=client.differentiable_output_paths,
+            jax.tree.unflatten(
+                params.output_pytreedef, range(len(params.output_avals))
+            ),
+            schema_paths=params.client.differentiable_output_paths,
         )
         out_path_to_aval = {
             path: aval
-            for (path, v), aval in zip(output_flat.items(), output_avals, strict=True)
+            for (path, v), aval in zip(
+                output_flat.items(), params.output_avals, strict=True
+            )
             if v is not None
         }
         jac_inputs = (
-            list(jac_input_paths)
-            if jac_input_paths is not None
+            list(params.jac_input_paths)
+            if params.jac_input_paths is not None
             else list(path_to_shape.keys())
         )
         jac_outputs = (
-            list(jac_output_paths)
-            if jac_output_paths is not None
+            list(params.jac_output_paths)
+            if params.jac_output_paths is not None
             else list(out_path_to_aval.keys())
         )
         # Per JAX convention: fwd-mode → output dtype (jacfwd), bwd-mode →
@@ -129,33 +124,23 @@ def tesseract_dispatch_abstract_eval(
             out_aval = out_path_to_aval[op_path]
             for ip in jac_inputs:
                 in_shape, in_dtype = path_to_shape[ip]
-                dtype = in_dtype if jac_mode == "bwd" else out_aval.dtype
+                dtype = in_dtype if params.jac_mode == "bwd" else out_aval.dtype
                 avals_out.append(
                     jax.core.ShapedArray(tuple(out_aval.shape) + in_shape, dtype)
                 )
         return tuple(avals_out)
 
     # Those have the same shape as the outputs
-    assert eval_func in ("apply", "jacobian_vector_product")
-    return tuple(jax.core.ShapedArray(aval.shape, aval.dtype) for aval in output_avals)
+    assert params.eval_func in ("apply", "jacobian_vector_product")
+    return tuple(
+        jax.core.ShapedArray(aval.shape, aval.dtype) for aval in params.output_avals
+    )
 
 
 def tesseract_dispatch_jvp_rule(
     in_args: tuple[ArrayLike, ...],
     tan_args: tuple[ArrayLike | ad.Zero, ...],
-    static_args: tuple[_Hashable, ...],
-    input_pytreedef: PyTreeDef,
-    output_pytreedef: PyTreeDef,
-    output_avals: tuple[ShapeDtypeStruct, ...],
-    is_static_mask: tuple[bool, ...],
-    has_tangent: tuple[bool, ...],
-    client: Jaxeract,
-    eval_func: str,
-    vmap_method: VmapMethod = None,
-    materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
-    jac_mode: Literal["fwd", "bwd"] = "bwd",
+    params: DispatchParams,
 ) -> tuple[tuple[ArrayLike, ...], tuple[ArrayLike, ...]]:
     """Defines how to dispatch jvp operation.
 
@@ -163,8 +148,14 @@ def tesseract_dispatch_jvp_rule(
     reverse-mode autodiff.
 
     """
-    if eval_func not in ("apply", "jacobian_vector_product", "vector_jacobian_product"):
-        raise RuntimeError(f"Cannot take higher-order derivatives of {eval_func!r}")
+    if params.eval_func not in (
+        "apply",
+        "jacobian_vector_product",
+        "vector_jacobian_product",
+    ):
+        raise RuntimeError(
+            f"Cannot take higher-order derivatives of {params.eval_func!r}"
+        )
 
     #  https://github.com/jax-ml/jax/issues/16303#issuecomment-1585295819
     #  mattjj: taking a narrow pigeon-holed view, anywhere you see a symbolic
@@ -172,9 +163,10 @@ def tesseract_dispatch_jvp_rule(
     #          (not in ad.py's backward_pass), you probably want to instantiate
     #          it so that it's no longer symbolic
 
-    n_primals = len(is_static_mask) - sum(is_static_mask)
+    n_primals = params.n_primals
+    has_tangent = params.has_tangent
 
-    if eval_func == "apply":
+    if params.eval_func == "apply":
         # Compute which primals have non-zero tangents
         has_tangent = tuple(not isinstance(t, jax._src.ad_util.Zero) for t in tan_args)
 
@@ -184,13 +176,13 @@ def tesseract_dispatch_jvp_rule(
         )
         _tangent_inputs = unflatten_args(
             _tangents_for_check,
-            static_args,
-            input_pytreedef,
-            is_static_mask,
+            params.static_args,
+            params.input_pytreedef,
+            params.is_static_mask,
             remove_static_args=True,
         )
         _flat_tangents = _pytree_to_tesseract_flat(
-            _tangent_inputs, schema_paths=client.differentiable_input_paths
+            _tangent_inputs, schema_paths=params.client.differentiable_input_paths
         )
         for path, val in _flat_tangents.items():
             if val is None:
@@ -229,7 +221,7 @@ def tesseract_dispatch_jvp_rule(
     # `jacfwd(lin_fn, argnums=0)` would ask for every column and then multiply the
     # unwanted ones by the zeros instantiated above.
     deriv_has_tangent = has_tangent
-    if eval_func == "jacobian_vector_product":
+    if params.eval_func == "jacobian_vector_product":
         deriv_has_tangent = tuple(
             not isinstance(t, jax._src.ad_util.Zero) for t in tan_args[n_primals:]
         )
@@ -238,34 +230,27 @@ def tesseract_dispatch_jvp_rule(
     jvp = tesseract_dispatch_p.bind(
         *in_args[:n_primals],
         *tan_args_,
-        static_args=static_args,
-        input_pytreedef=input_pytreedef,
-        output_pytreedef=output_pytreedef,
-        output_avals=output_avals,
-        is_static_mask=is_static_mask,
-        has_tangent=deriv_has_tangent,
-        client=client,
-        eval_func=(
-            "vector_jacobian_product"
-            if eval_func == "vector_jacobian_product"
-            else "jacobian_vector_product"
+        params=params.replace(
+            has_tangent=deriv_has_tangent,
+            eval_func=(
+                "vector_jacobian_product"
+                if params.eval_func == "vector_jacobian_product"
+                else "jacobian_vector_product"
+            ),
+            jac_input_paths=None,
+            jac_output_paths=None,
+            jac_mode="bwd",
         ),
-        vmap_method=vmap_method,
-        materialize_jacobian=materialize_jacobian,
     )
 
     res = tesseract_dispatch_p.bind(
         *in_args,
-        static_args=static_args,
-        input_pytreedef=input_pytreedef,
-        output_pytreedef=output_pytreedef,
-        output_avals=output_avals,
-        is_static_mask=is_static_mask,
-        has_tangent=has_tangent,
-        client=client,
-        eval_func=eval_func,
-        vmap_method=vmap_method,
-        materialize_jacobian=materialize_jacobian,
+        params=params.replace(
+            has_tangent=has_tangent,
+            jac_input_paths=None,
+            jac_output_paths=None,
+            jac_mode="bwd",
+        ),
     )
 
     return tuple(res), tuple(jvp)
@@ -277,21 +262,12 @@ ad.primitive_jvps[tesseract_dispatch_p] = tesseract_dispatch_jvp_rule
 def tesseract_dispatch_transpose_rule(
     cotangent: Sequence[ArrayLike | ad.Zero],
     *args: ArrayLike | ad.UndefinedPrimal,
-    static_args: tuple[_Hashable, ...],
-    input_pytreedef: PyTreeDef,
-    output_pytreedef: PyTreeDef,
-    output_avals: tuple[ShapeDtypeStruct, ...],
-    is_static_mask: tuple[bool, ...],
-    has_tangent: tuple[bool, ...],
-    client: Jaxeract,
-    eval_func: str,
-    vmap_method: VmapMethod = None,
-    materialize_jacobian: bool | None = None,
+    params: DispatchParams,
 ) -> tuple[ArrayLike | None, ...]:
     """Defines how to dispatch vjp operation."""
-    assert eval_func in ("jacobian_vector_product",)
+    assert params.eval_func in ("jacobian_vector_product",)
 
-    n_primals = len(is_static_mask) - sum(is_static_mask)
+    n_primals = params.n_primals
     primal_args = args[:n_primals]
 
     # Primal slots must hold concrete residuals. An UndefinedPrimal here means the
@@ -315,9 +291,11 @@ def tesseract_dispatch_transpose_rule(
     # (e.g. via jax.lax.stop_gradient) or when the output is not used in the loss.
     # Any other cotangent means the user accidentally included a non-diff output
     # in the gradient computation, likely due to a missing Differentiable[] annotation.
-    dummy_output = jax.tree.unflatten(output_pytreedef, range(len(output_avals)))
+    dummy_output = jax.tree.unflatten(
+        params.output_pytreedef, range(len(params.output_avals))
+    )
     flat_output_info = _pytree_to_tesseract_flat(
-        dummy_output, schema_paths=client.differentiable_output_paths
+        dummy_output, schema_paths=params.client.differentiable_output_paths
     )
     for cotan, (path, is_diff) in zip(cotangent, flat_output_info.items(), strict=True):
         if is_diff is None and not isinstance(cotan, jax._src.ad_util.Zero):
@@ -331,16 +309,16 @@ def tesseract_dispatch_transpose_rule(
 
     # Raise if a gradient is requested for a non-differentiable input.
     _primal_inputs = unflatten_args(
-        primal_args, static_args, input_pytreedef, is_static_mask
+        primal_args, params.static_args, params.input_pytreedef, params.is_static_mask
     )
     _flat_inputs = _pytree_to_tesseract_flat(
-        _primal_inputs, schema_paths=client.differentiable_input_paths
+        _primal_inputs, schema_paths=params.client.differentiable_input_paths
     )
     _non_static_paths = [
-        p for p, m in zip(_flat_inputs, is_static_mask, strict=True) if not m
+        p for p, m in zip(_flat_inputs, params.is_static_mask, strict=True) if not m
     ]
     _vjp_inputs_with_tangent = [
-        p for p, h in zip(_non_static_paths, has_tangent, strict=True) if h
+        p for p, h in zip(_non_static_paths, params.has_tangent, strict=True) if h
     ]
     for path in _vjp_inputs_with_tangent:
         if _flat_inputs[path] is None:
@@ -358,16 +336,7 @@ def tesseract_dispatch_transpose_rule(
     vjp = tesseract_dispatch_p.bind(
         *primal_args,
         *cotan_args_,
-        static_args=static_args,
-        input_pytreedef=input_pytreedef,
-        output_pytreedef=output_pytreedef,
-        output_avals=output_avals,
-        is_static_mask=is_static_mask,
-        has_tangent=has_tangent,
-        client=client,
-        eval_func="vector_jacobian_product",
-        vmap_method=vmap_method,
-        materialize_jacobian=materialize_jacobian,
+        params=params.replace(eval_func="vector_jacobian_product"),
     )
 
     return tuple([None] * len(primal_args) + list(vjp))
@@ -387,45 +356,17 @@ def _raise_if_unimplemented(eval_func: str, client: Jaxeract) -> None:
 
 def tesseract_dispatch(
     *array_args: ArrayLike | ShapedArray | Any,
-    static_args: tuple[_Hashable, ...],
-    input_pytreedef: PyTreeDef,
-    output_pytreedef: PyTreeDef | None,
-    output_avals: tuple[ShapeDtypeStruct, ...] | None,
-    is_static_mask: tuple[bool, ...],
-    has_tangent: tuple[bool, ...],
-    client: Jaxeract,
-    eval_func: str,
-    vmap_method: VmapMethod = None,
-    materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
-    jac_mode: Literal["fwd", "bwd"] = "bwd",
+    params: DispatchParams,
 ) -> Any:
     """Defines how to dispatch lowering the computation.
 
     The dispatch that is not lowered is only called in cases where abstract eval is not needed.
     """
-    _raise_if_unimplemented(eval_func, client)
-
-    extra_kwargs: dict[str, Any] = {}
-    if eval_func == "jacobian":
-        extra_kwargs["jac_input_paths"] = jac_input_paths
-        extra_kwargs["jac_output_paths"] = jac_output_paths
-        extra_kwargs["jac_mode"] = jac_mode
+    _raise_if_unimplemented(params.eval_func, params.client)
 
     def _dispatch(*args: ArrayLike) -> Any:
-        static_args_ = tuple(_unpack_hashable(arg) for arg in static_args)
-        out = getattr(client, eval_func)(
-            args,
-            static_args_,
-            input_pytreedef,
-            output_pytreedef,
-            output_avals,
-            is_static_mask,
-            has_tangent,
-            **extra_kwargs,
-        )
-        if not isinstance(out, tuple) and output_avals is not None:
+        out = getattr(params.client, params.eval_func)(args, params)
+        if not isinstance(out, tuple) and params.output_avals is not None:
             out = (out,)
         return out
 
@@ -439,41 +380,13 @@ tesseract_dispatch_p.def_impl(tesseract_dispatch)
 def tesseract_dispatch_lowering(
     ctx: Any,
     *array_args: ArrayLike | ShapedArray | Any,
-    static_args: tuple[_Hashable, ...],
-    input_pytreedef: PyTreeDef,
-    output_pytreedef: PyTreeDef,
-    output_avals: tuple[ShapeDtypeStruct, ...],
-    is_static_mask: tuple[bool, ...],
-    has_tangent: tuple[bool, ...],
-    client: Jaxeract,
-    eval_func: str,
-    vmap_method: VmapMethod = None,
-    materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
-    jac_mode: Literal["fwd", "bwd"] = "bwd",
+    params: DispatchParams,
 ) -> Any:
     """Defines how to dispatch lowering the computation."""
-    _raise_if_unimplemented(eval_func, client)
-
-    extra_kwargs: dict[str, Any] = {}
-    if eval_func == "jacobian":
-        extra_kwargs["jac_input_paths"] = jac_input_paths
-        extra_kwargs["jac_output_paths"] = jac_output_paths
-        extra_kwargs["jac_mode"] = jac_mode
+    _raise_if_unimplemented(params.eval_func, params.client)
 
     def _dispatch(*args: ArrayLike) -> Any:
-        static_args_ = tuple(_unpack_hashable(arg) for arg in static_args)
-        out = getattr(client, eval_func)(
-            args,
-            static_args_,
-            input_pytreedef,
-            output_pytreedef,
-            output_avals,
-            is_static_mask,
-            has_tangent,
-            **extra_kwargs,
-        )
+        out = getattr(params.client, params.eval_func)(args, params)
         if not isinstance(out, tuple):
             out = (out,)
         return out
@@ -508,38 +421,26 @@ def tesseract_dispatch_batching(
     array_args: ArrayLike | ShapedArray | Any,
     axes: Sequence[Any],
     *,
-    static_args: tuple[_Hashable, ...],
-    input_pytreedef: PyTreeDef,
-    output_pytreedef: PyTreeDef,
-    output_avals: tuple[ShapeDtypeStruct, ...],
-    is_static_mask: tuple[bool, ...],
-    has_tangent: tuple[bool, ...],
-    client: Jaxeract,
-    eval_func: str,
-    vmap_method: VmapMethod = None,
-    materialize_jacobian: bool | None = None,
-    jac_input_paths: tuple[str, ...] | None = None,
-    jac_output_paths: tuple[str, ...] | None = None,
-    jac_mode: Literal["fwd", "bwd"] = "bwd",
+    params: DispatchParams,
 ) -> Any:
     """Defines how to dispatch batch operations such as vmap (which is used by jax.jacobian)."""
-    _raise_if_unimplemented(eval_func, client)
+    _raise_if_unimplemented(params.eval_func, params.client)
 
     # An unmapped axis is denoted by ``None``. (Older JAX versions exposed this
     # as the ``batching.not_mapped`` sentinel, which has since been removed; it
     # was always equal to ``None``.)
-    n_primals = len(is_static_mask) - sum(is_static_mask)
+    n_primals = params.n_primals
 
     # When jacfwd/jacrev vmap a JVP/VJP with primals unbatched and (co)tangents
     # batched, materialize the entire Jacobian and apply to batch with matmul.
     # Gated by ``materialize_jacobian`` (None = auto, True = force, False = skip).
-    if eval_func in ("jacobian_vector_product", "vector_jacobian_product"):
+    if params.eval_func in ("jacobian_vector_product", "vector_jacobian_product"):
         primal_axes = axes[:n_primals]
         tangent_axes = axes[n_primals:]
         primals_unbatched = all(ax is None for ax in primal_axes)
         tangents_batched = any(ax is not None for ax in tangent_axes)
-        endpoint_available = "jacobian" in client.available_methods
-        if materialize_jacobian is True and not endpoint_available:
+        endpoint_available = "jacobian" in params.client.available_methods
+        if params.materialize_jacobian is True and not endpoint_available:
             raise RuntimeError(
                 "materialize_jacobian=True but the Tesseract does not expose a "
                 "'jacobian' endpoint."
@@ -547,23 +448,11 @@ def tesseract_dispatch_batching(
         use_shortcut = (
             primals_unbatched
             and tangents_batched
-            and materialize_jacobian is not False
-            and (materialize_jacobian is True or endpoint_available)
+            and params.materialize_jacobian is not False
+            and (params.materialize_jacobian is True or endpoint_available)
         )
         if use_shortcut:
-            return _batched_via_jacobian(
-                array_args,
-                axes,
-                static_args=static_args,
-                input_pytreedef=input_pytreedef,
-                output_pytreedef=output_pytreedef,
-                output_avals=output_avals,
-                is_static_mask=is_static_mask,
-                has_tangent=has_tangent,
-                client=client,
-                eval_func=eval_func,
-                vmap_method=vmap_method,
-            )
+            return _batched_via_jacobian(array_args, axes, params=params)
 
     new_args = [
         arg if ax is None else jnp.moveaxis(arg, ax, 0)
@@ -571,31 +460,19 @@ def tesseract_dispatch_batching(
     ]
     is_batched_mask = [ax is not None for ax in axes]
 
-    if eval_func == "jacobian":
+    if params.eval_func == "jacobian":
         # The vectorized strategies hand batched primals to the endpoint, which
         # then answers with a (batch, *out, batch, *in) block rather than
         # (batch, *out, *in). Only sequential wraps a jacobian call correctly,
         # and the mismatch is silent rather than an error, so pin it here.
-        vmap_method = "sequential"
+        params = params.replace(vmap_method="sequential")
 
-    batch_fn = VMAP_METHOD_DISPATCH[vmap_method]
+    batch_fn = VMAP_METHOD_DISPATCH[params.vmap_method]
     return batch_fn(
         new_args,
         is_batched_mask,
-        static_args=static_args,
-        input_pytreedef=input_pytreedef,
-        output_pytreedef=output_pytreedef,
-        output_avals=output_avals,
-        is_static_mask=is_static_mask,
-        has_tangent=has_tangent,
-        client=client,
-        eval_func=eval_func,
-        vmap_method=vmap_method,
+        params=params,
         tesseract_dispatch_p=tesseract_dispatch_p,
-        materialize_jacobian=materialize_jacobian,
-        jac_input_paths=jac_input_paths,
-        jac_output_paths=jac_output_paths,
-        jac_mode=jac_mode,
     )
 
 
@@ -603,15 +480,7 @@ def _batched_via_jacobian(
     array_args: Sequence[Any],
     axes: Sequence[Any],
     *,
-    static_args: tuple[_Hashable, ...],
-    input_pytreedef: PyTreeDef,
-    output_pytreedef: PyTreeDef,
-    output_avals: tuple[ShapeDtypeStruct, ...],
-    is_static_mask: tuple[bool, ...],
-    has_tangent: tuple[bool, ...],
-    client: Jaxeract,
-    eval_func: str,
-    vmap_method: VmapMethod = None,
+    params: DispatchParams,
 ) -> tuple[tuple, tuple]:
     """Batched JVP / VJP via one ``jacobian`` endpoint call + ``tensordot``.
 
@@ -619,7 +488,7 @@ def _batched_via_jacobian(
     (caller checks). Returns ``(out_vals, out_axes)`` per JAX batching rule
     convention; output batch axis is always 0.
     """
-    n_primals = len(is_static_mask) - sum(is_static_mask)
+    n_primals = params.n_primals
     primals = tuple(array_args[:n_primals])  # unbatched
     raw_tans = array_args[n_primals:]
     tan_axes = axes[n_primals:]
@@ -641,14 +510,14 @@ def _batched_via_jacobian(
     tans = jax.tree.map(_to_batched, raw_tans, tan_axes)
 
     primal_inputs = unflatten_args(
-        primals, static_args, input_pytreedef, is_static_mask
+        primals, params.static_args, params.input_pytreedef, params.is_static_mask
     )
     flat_inputs = _pytree_to_tesseract_flat(
-        primal_inputs, schema_paths=client.differentiable_input_paths
+        primal_inputs, schema_paths=params.client.differentiable_input_paths
     )
     output_flat = _pytree_to_tesseract_flat(
-        jax.tree.unflatten(output_pytreedef, range(len(output_avals))),
-        schema_paths=client.differentiable_output_paths,
+        jax.tree.unflatten(params.output_pytreedef, range(len(params.output_avals))),
+        schema_paths=params.client.differentiable_output_paths,
     )
 
     # Map each (schema-diff) ∧ (has_tangent) input path to its position in
@@ -657,10 +526,12 @@ def _batched_via_jacobian(
     # JAX-zero tangents (JVP) and non-requested gradients (VJP).
     diff_input_path_to_pos: dict[str, int] = {}
     non_static_idx = 0
-    for (p, v), is_static in zip(flat_inputs.items(), is_static_mask, strict=True):
+    for (p, v), is_static in zip(
+        flat_inputs.items(), params.is_static_mask, strict=True
+    ):
         if is_static:
             continue
-        if v is not None and has_tangent[non_static_idx]:
+        if v is not None and params.has_tangent[non_static_idx]:
             diff_input_path_to_pos[p] = non_static_idx
         non_static_idx += 1
 
@@ -673,18 +544,12 @@ def _batched_via_jacobian(
 
     jac_arrays = tesseract_dispatch_p.bind(
         *primals,
-        static_args=static_args,
-        input_pytreedef=input_pytreedef,
-        output_pytreedef=output_pytreedef,
-        output_avals=output_avals,
-        is_static_mask=is_static_mask,
-        has_tangent=has_tangent,
-        client=client,
-        eval_func="jacobian",
-        vmap_method=vmap_method,
-        jac_input_paths=tuple(diff_input_path_to_pos),
-        jac_output_paths=tuple(diff_output_path_to_pos),
-        jac_mode="fwd" if eval_func == "jacobian_vector_product" else "bwd",
+        params=params.replace(
+            eval_func="jacobian",
+            jac_input_paths=tuple(diff_input_path_to_pos),
+            jac_output_paths=tuple(diff_output_path_to_pos),
+            jac_mode="fwd" if params.eval_func == "jacobian_vector_product" else "bwd",
+        ),
     )
     n_in = len(diff_input_path_to_pos)
     n_out = len(diff_output_path_to_pos)
@@ -731,11 +596,11 @@ def _batched_via_jacobian(
     # level: those are flat lists of leaves, so each rest-arg's subtree at
     # that position is passed whole.
 
-    if eval_func == "jacobian_vector_product":
+    if params.eval_func == "jacobian_vector_product":
         # Filter tangents to matrix-column order, then for each diff row sum
         # the per-column matvec contributions.
         filtered_tans = [tans[pos] for pos in diff_input_path_to_pos.values()]
-        diff_avals = [output_avals[i] for i in diff_output_path_to_pos.values()]
+        diff_avals = [params.output_avals[i] for i in diff_output_path_to_pos.values()]
         diff_outs = jax.tree.map(
             lambda slot, jac_row: _tree_sum(
                 jax.tree.map(_matmul, jac_row, filtered_tans), slot
@@ -745,7 +610,7 @@ def _batched_via_jacobian(
         )
         outs = _pad_nans(
             diff_outs,
-            output_avals,
+            params.output_avals,
             [v is not None for _p, v in output_flat.items()],
         )
         return outs, (0,) * len(outs)
@@ -797,10 +662,6 @@ def _check_dtype(dtype: Any) -> None:
 
 def _make_hashable(obj: Any) -> _Hashable:
     return _Hashable(obj)
-
-
-def _unpack_hashable(obj: _Hashable) -> Any:
-    return obj.wrapped
 
 
 def _is_array_schema(prop_schema: dict) -> bool:
@@ -1088,16 +949,18 @@ def apply_tesseract(
         # Apply the primitive
         out = tesseract_dispatch_p.bind(
             *array_args,
-            static_args=static_args,
-            input_pytreedef=input_pytreedef,
-            output_pytreedef=output_pytreedef,
-            output_avals=flat_avals,
-            is_static_mask=is_static_mask,
-            has_tangent=has_tangent,
-            client=client,
-            eval_func="apply",
-            vmap_method=vmap_method,
-            materialize_jacobian=materialize_jacobian,
+            params=DispatchParams(
+                static_args=static_args,
+                input_pytreedef=input_pytreedef,
+                output_pytreedef=output_pytreedef,
+                output_avals=flat_avals,
+                is_static_mask=is_static_mask,
+                has_tangent=has_tangent,
+                client=client,
+                eval_func="apply",
+                vmap_method=vmap_method,
+                materialize_jacobian=materialize_jacobian,
+            ),
         )
 
         # Unflatten the output
@@ -1109,16 +972,18 @@ def apply_tesseract(
         # and the primitive will return an unflattened output
         out = tesseract_dispatch_p.bind(
             *array_args,
-            static_args=static_args,
-            input_pytreedef=input_pytreedef,
-            output_pytreedef=None,
-            output_avals=None,
-            is_static_mask=is_static_mask,
-            has_tangent=has_tangent,
-            client=client,
-            eval_func="apply",
-            vmap_method=vmap_method,
-            materialize_jacobian=materialize_jacobian,
+            params=DispatchParams(
+                static_args=static_args,
+                input_pytreedef=input_pytreedef,
+                output_pytreedef=None,
+                output_avals=None,
+                is_static_mask=is_static_mask,
+                has_tangent=has_tangent,
+                client=client,
+                eval_func="apply",
+                vmap_method=vmap_method,
+                materialize_jacobian=materialize_jacobian,
+            ),
         )
 
         # Unflatten the output

--- a/tesseract_jax/tesseract_compat.py
+++ b/tesseract_jax/tesseract_compat.py
@@ -1,12 +1,10 @@
 # Copyright 2025 Pasteur Labs. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Literal
+from typing import TYPE_CHECKING
 
 import jax.tree
 import numpy as np
-from jax import ShapeDtypeStruct
-from jax.tree_util import PyTreeDef
 from jax.typing import ArrayLike
 from tesseract_core import Tesseract
 
@@ -16,6 +14,9 @@ from tesseract_jax.tree_util import (
     combine_args,
     unflatten_args,
 )
+
+if TYPE_CHECKING:
+    from tesseract_jax.dispatch_params import DispatchParams
 
 # WARNING: Do NOT use jax.numpy within Jaxeract methods, as they are executed from within FFI callbacks
 # and cannot safely allocate JAX arrays. Use vanilla numpy instead.
@@ -97,21 +98,19 @@ class Jaxeract:
     def apply(
         self,
         array_args: tuple[ArrayLike, ...],
-        static_args: tuple[Any, ...],
-        input_pytreedef: PyTreeDef,
-        output_pytreedef: PyTreeDef | None,
-        output_avals: tuple[ShapeDtypeStruct, ...] | None,
-        is_static_mask: tuple[bool, ...],
-        has_tangent: tuple[bool, ...],
+        params: "DispatchParams",
     ) -> PyTree:
         """Call the Tesseract's apply endpoint with the given arguments."""
         inputs = unflatten_args(
-            array_args, static_args, input_pytreedef, is_static_mask
+            array_args,
+            params.static_args,
+            params.input_pytreedef,
+            params.is_static_mask,
         )
 
         out_data = self.client.apply(inputs)
 
-        if output_avals is None:
+        if params.output_avals is None:
             return out_data
 
         out_data = tuple(jax.tree.flatten(out_data)[0])
@@ -120,15 +119,11 @@ class Jaxeract:
     def jacobian_vector_product(
         self,
         array_args: tuple[ArrayLike, ...],
-        static_args: tuple[Any, ...],
-        input_pytreedef: PyTreeDef,
-        output_pytreedef: PyTreeDef,
-        output_avals: tuple[ShapeDtypeStruct, ...],
-        is_static_mask: tuple[bool, ...],
-        has_tangent: tuple[bool, ...],
+        params: "DispatchParams",
     ) -> PyTree:
         """Call the Tesseract's jvp endpoint with the given arguments."""
-        n_primals = len(is_static_mask) - sum(is_static_mask)
+        has_tangent = params.has_tangent
+        n_primals = params.n_primals
         primals = array_args[:n_primals]
         # array_args[n_primals:] contains ALL tangents (zeroed for has_tangent=False).
         # Filter to only the has_tangent=True ones before calling combine_args, which
@@ -142,13 +137,13 @@ class Jaxeract:
         full_tangents = combine_args([None] * n_zeros, tangents, has_tangent)
 
         primal_inputs = unflatten_args(
-            primals, static_args, input_pytreedef, is_static_mask
+            primals, params.static_args, params.input_pytreedef, params.is_static_mask
         )
         tangent_inputs = unflatten_args(
             full_tangents,
-            static_args,
-            input_pytreedef,
-            is_static_mask,
+            params.static_args,
+            params.input_pytreedef,
+            params.is_static_mask,
             remove_static_args=True,
         )
 
@@ -158,7 +153,9 @@ class Jaxeract:
         flat_tangents = {p: v for p, v in flat_tangents.items() if v is not None}
 
         output_flat = _pytree_to_tesseract_flat(
-            jax.tree.unflatten(output_pytreedef, range(len(output_avals))),
+            jax.tree.unflatten(
+                params.output_pytreedef, range(len(params.output_avals))
+            ),
             schema_paths=self.differentiable_output_paths,
         )
 
@@ -172,7 +169,7 @@ class Jaxeract:
         )
 
         out = []
-        for path, aval in zip(output_flat, output_avals, strict=False):
+        for path, aval in zip(output_flat, params.output_avals, strict=False):
             if path in out_data:
                 out.append(out_data[path])
             else:
@@ -183,47 +180,41 @@ class Jaxeract:
     def jacobian(
         self,
         array_args: tuple[ArrayLike, ...],
-        static_args: tuple[Any, ...],
-        input_pytreedef: PyTreeDef,
-        output_pytreedef: PyTreeDef,
-        output_avals: tuple[ShapeDtypeStruct, ...],
-        is_static_mask: tuple[bool, ...],
-        has_tangent: tuple[bool, ...],
-        jac_input_paths: tuple[str, ...] | None = None,
-        jac_output_paths: tuple[str, ...] | None = None,
-        jac_mode: Literal["fwd", "bwd"] = "bwd",
+        params: "DispatchParams",
     ) -> PyTree:
         """Call the Tesseract's jacobian endpoint with the given arguments.
 
         Returns one ndarray per (requested_output, requested_input) pair, in
         row-major order. Each array has shape ``out_shape + in_shape`` and
-        dtype determined by ``jac_mode`` (``"bwd"`` matches ``jax.jacrev``
+        dtype determined by ``params.jac_mode`` (``"bwd"`` matches ``jax.jacrev``
         and uses input dtype; ``"fwd"`` matches ``jax.jacfwd`` and uses
         output dtype). Mirrors lineax's mode names.
         """
-        n_primals = len(is_static_mask) - sum(is_static_mask)
+        n_primals = params.n_primals
         primals = array_args[:n_primals]
 
         primal_inputs = unflatten_args(
-            primals, static_args, input_pytreedef, is_static_mask
+            primals, params.static_args, params.input_pytreedef, params.is_static_mask
         )
 
         flat_inputs = _pytree_to_tesseract_flat(
             primal_inputs, schema_paths=self.differentiable_input_paths
         )
-        if jac_input_paths is None:
+        if params.jac_input_paths is None:
             jac_inputs = [p for p, v in flat_inputs.items() if v is not None]
         else:
-            jac_inputs = list(jac_input_paths)
+            jac_inputs = list(params.jac_input_paths)
 
         output_flat = _pytree_to_tesseract_flat(
-            jax.tree.unflatten(output_pytreedef, range(len(output_avals))),
+            jax.tree.unflatten(
+                params.output_pytreedef, range(len(params.output_avals))
+            ),
             schema_paths=self.differentiable_output_paths,
         )
-        if jac_output_paths is None:
+        if params.jac_output_paths is None:
             jac_outputs = [p for p, v in output_flat.items() if v is not None]
         else:
-            jac_outputs = list(jac_output_paths)
+            jac_outputs = list(params.jac_output_paths)
 
         out_data = self.client.jacobian(
             inputs=primal_inputs,
@@ -234,33 +225,33 @@ class Jaxeract:
         ip_to_dtype = {p: v.dtype for p, v in flat_inputs.items() if v is not None}
         op_to_dtype = {
             p: aval.dtype
-            for (p, v), aval in zip(output_flat.items(), output_avals, strict=True)
+            for (p, v), aval in zip(
+                output_flat.items(), params.output_avals, strict=True
+            )
             if v is not None
         }
         out = []
         for op in jac_outputs:
             for ip in jac_inputs:
-                target = ip_to_dtype[ip] if jac_mode == "bwd" else op_to_dtype[op]
+                target = (
+                    ip_to_dtype[ip] if params.jac_mode == "bwd" else op_to_dtype[op]
+                )
                 out.append(np.asarray(out_data[op][ip], dtype=target))
         return tuple(out)
 
     def vector_jacobian_product(
         self,
         array_args: tuple[ArrayLike, ...],
-        static_args: tuple[Any, ...],
-        input_pytreedef: PyTreeDef,
-        output_pytreedef: PyTreeDef,
-        output_avals: tuple[ShapeDtypeStruct, ...],
-        is_static_mask: tuple[bool, ...],
-        has_tangent: tuple[bool, ...],
+        params: "DispatchParams",
     ) -> PyTree:
         """Call the Tesseract's vjp endpoint with the given arguments."""
-        n_primals = len(is_static_mask) - sum(is_static_mask)
+        has_tangent = params.has_tangent
+        n_primals = params.n_primals
         primals = array_args[:n_primals]
         cotangents = array_args[n_primals:]
 
         primal_inputs = unflatten_args(
-            primals, static_args, input_pytreedef, is_static_mask
+            primals, params.static_args, params.input_pytreedef, params.is_static_mask
         )
 
         flat_inputs = _pytree_to_tesseract_flat(
@@ -268,13 +259,13 @@ class Jaxeract:
         )
 
         vjp_inputs = [
-            p for p, m in zip(flat_inputs, is_static_mask, strict=True) if not m
+            p for p, m in zip(flat_inputs, params.is_static_mask, strict=True) if not m
         ]
 
         # now we filter for tangents
         vjp_inputs = [p for p, h in zip(vjp_inputs, has_tangent, strict=True) if h]
 
-        cotangent_pytree = jax.tree.unflatten(output_pytreedef, cotangents)
+        cotangent_pytree = jax.tree.unflatten(params.output_pytreedef, cotangents)
         flat_cotangents = _pytree_to_tesseract_flat(
             cotangent_pytree, schema_paths=self.differentiable_output_paths
         )
@@ -301,7 +292,7 @@ class Jaxeract:
                 tan_idx += 1
             elif (
                 tan_idx < len(has_tangent)
-                and not is_static_mask[all_idx]
+                and not params.is_static_mask[all_idx]
                 and not has_tangent[tan_idx]
             ):
                 # Non-differentiable but non-static input: return a NaN
@@ -319,7 +310,7 @@ class Jaxeract:
                 tan_idx += 1
 
             # Increment array_idx only for non-static inputs (which appear in array_args)
-            if not is_static_mask[all_idx]:
+            if not params.is_static_mask[all_idx]:
                 array_idx += 1
 
         return tuple(out)


### PR DESCRIPTION
#### Description of changes

The `tesseract_dispatch` primitive threaded ~13 descriptors — pytreedefs, static/tangent masks, output avals, the `Jaxeract` client, `eval_func`, and the vmap/jacobian options — as individual keyword arguments through every primitive rule (abstract-eval, jvp, transpose, impl, lowering, batching), every batching strategy, and every `Jaxeract` endpoint method. The signatures had grown to a dozen-plus parameters each and every `bind()` call restated the whole set, which made them noisy to read and easy to get out of sync.

This bundles them into a single frozen `DispatchParams` dataclass (new `dispatch_params.py`) carried as one bind parameter. The dataclass also absorbs two bits of repetition: an `n_primals` property (previously recomputed inline in ~8 places) and a `replace()` helper for the derived binds. No behavior change — purely a signature refactor.

The dataclass is frozen with all-hashable fields, which is what keeps JAX's bind-param equality intact and preserves XLA's CSE folding of identical Tesseract calls (`Jaxeract` still supplies its own `__eq__`/`__hash__`).

#### Testing done

- Full suite: `279 passed`.
- Ruff check + format clean.
- Confirmed the CSE invariant still holds via the existing `test_identical_calls_are_commoned_up` / `test_distinct_calls_are_not_commoned_up` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)