### PR TITLE
refactor: drop cotangents for non-linear tangent slots in transpose rule

### DIFF
--- a/tesseract_jax/primitive.py
+++ b/tesseract_jax/primitive.py
@@ -370,7 +370,20 @@ def tesseract_dispatch_transpose_rule(
         materialize_jacobian=materialize_jacobian,
     )
 
-    return tuple([None] * len(primal_args) + list(vjp))
+    # Only the tangent slots JAX is actually transposing (its UndefinedPrimals)
+    # are linear positions that want a cotangent. A slot whose tangent was a
+    # materialised zero -- a non-differentiable or simply undifferentiated input
+    # -- is a constant, so JAX wants nothing for it, exactly as for the primal
+    # slots above. The dispatch still returns a value in those slots to satisfy
+    # the output-tuple-length contract; dropping them here keeps those discarded
+    # values out of the cotangent accumulation entirely, rather than relying on
+    # JAX to ignore them downstream.
+    tangent_args = args[n_primals:]
+    vjp_cotangents = [
+        ct if ad.is_undefined_primal(t) else None
+        for ct, t in zip(vjp, tangent_args, strict=True)
+    ]
+    return tuple([None] * len(primal_args) + vjp_cotangents)
 
 
 ad.primitive_transposes[tesseract_dispatch_p] = tesseract_dispatch_transpose_rule


### PR DESCRIPTION
Split out of the review of #239, where the discussion was about what value the discarded gradient slots should hold. This is the other half of that: making sure nothing reads them in the first place.

## What

`tesseract_dispatch_transpose_rule` returned every value the vjp dispatch produced:

```python
return tuple([None] * len(primal_args) + list(vjp))
```

Some of those tangent slots are not linear positions. A tangent that was a symbolic zero — a non-differentiable input, or one simply not being differentiated — gets materialised by `_instantiate_zeros` before `bind`, so at transpose time it is a *constant*, not an `UndefinedPrimal`. JAX wants no cotangent for those, which is exactly why the primal slots already return `None`.

This selects on `ad.is_undefined_primal`, JAX's own criterion for "this position is being transposed", and returns `None` for the rest.

## What this does and does not change

- **No user-visible gradient changes.** The dropped values were never consumed; JAX accumulated them into a cotangent slot keyed on a constant and then discarded them.
- **It does not remove the buffers.** The vjp abstract eval still returns one aval per primal (`primitive.py:85-88`), so XLA still allocates those slots and the dispatch still fills them. Whatever fill value they get remains a live question — that part belongs in #239, and properly removing them is output pruning, which is a feature rather than a cleanup.
- **What it does buy:** the "these values are never consumed" invariant becomes structural instead of relying on JAX to ignore them downstream. That matters more once the slots are deliberately poisoned, since a NaN can no longer reach a cotangent accumulation even in principle.

## Testing

Full suite on this branch: **279 passed**, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
